### PR TITLE
refactor: update sizing scale to include 14px icon size

### DIFF
--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -50,7 +50,8 @@ $z-modal: 30
 $z-notification: 40
 
 // Sizing Scale (for heights, widths)
-$size-2xs: 0.75rem   // 12px - 2x small
+$size-3xs: 0.75rem   // 12px - 3x small
+$size-2xs: 0.875rem  // 14px - 2x small
 $size-xs: 1rem       // 16px - extra small
 $size-sm: 1.125rem   // 18px - small
 $size-md: 1.25rem    // 20px - medium


### PR DESCRIPTION
- Add $size-3xs: 0.75rem (12px) for smaller icon needs
- Update $size-2xs from 12px to 14px (0.875rem)
- Affects icon sizes in HintText and Label components

🤖 Generated with [Claude Code](https://claude.ai/code)