### PR TITLE
fix: adjust switch thumb alignment for better visual balance

### DIFF
--- a/src/components/Switch/LbSwitch.vue
+++ b/src/components/Switch/LbSwitch.vue
@@ -112,7 +112,7 @@ defineExpose({
   .switch-thumb
     position: absolute
     top: 50%
-    left: base.$space-2 // 4px
+    left: 2px
     transform: translateY(-50%)
     width: base.$size-lg // 24px
     height: base.$size-lg // 24px
@@ -129,7 +129,7 @@ defineExpose({
       
     .switch-thumb
       background: white
-      transform: translateY(-50%) translateX(base.$space-9 + base.$space-1) // Move 22px to right (20px + 2px)
+      transform: translateY(-50%) translateX(base.$space-9 + base.$space-2) // Move 24px to right (20px + 4px)
       
   // Add smooth spring animation for the toggle
   &:not(.disabled) .switch-thumb


### PR DESCRIPTION
- Move off-state thumb 2px closer to left edge (from 4px to 2px)
- Move on-state thumb 2px further right (from 22px to 24px)
- Improves visual alignment in both toggle states

🤖 Generated with [Claude Code](https://claude.ai/code)