### PR TITLE
fix: remove focus ring animation on buttons

### DIFF
--- a/src/components/Button/LbButton.vue
+++ b/src/components/Button/LbButton.vue
@@ -156,6 +156,7 @@ defineOptions({
   &:focus-visible
     outline: base.$focus-ring-width solid var(--color-focus-ring)
     outline-offset: base.$focus-ring-offset
+    transition: none
   
   // Size modifiers
   &.small


### PR DESCRIPTION
Add transition: none to button focus-visible state to ensure the focus ring appears instantly when tabbing between buttons, improving keyboard navigation experience.

🤖 Generated with [Claude Code](https://claude.ai/code)