### PR TITLE
feat: add LbSegmentButton component with Material Design 3 styling

### DIFF
--- a/context/timist-components-needed.md
+++ b/context/timist-components-needed.md
@@ -4,8 +4,8 @@
 These components need to be built in LittleBrand UI Kit to support the Timist application migration. Components are organized by development day with complexity ratings.
 
 Total components to build: 7 (3 simple, 3 medium, 1 complex)
-Completed: 4 (Badge ✅, Progress ✅, Avatar ✅, Snackbar ✅)
-Remaining: 3
+Completed: 5 (Badge ✅, Progress ✅, Avatar ✅, Snackbar ✅, Divider ✅)
+Remaining: 2
 
 ## Day 1: Simple Components (3 components)
 
@@ -23,7 +23,7 @@ Remaining: 3
   - Size options
   - Inline-block display
 
-### 2. Divider ❌ (Not Started)
+### 2. Divider ✅ (Completed)
 - **Purpose**: Visual divider between sections
 - **Complexity**: ⭐ (Simple)
 - **API Requirements**:

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1558,13 +1558,181 @@
             .list-item
               h5 Notifications
               p Choose what updates you receive
+      
+      .component-demo
+        h3 Segment Button
+        p Single-select buttons for filtering and content switching
+        
+        .demo-group
+          h4 Basic Segment Buttons
+          .segment-demo
+            LbSegmentButton(v-model="selectedSegment1")
+              LbSegmentButtonItem(value="all") All
+              LbSegmentButtonItem(value="active") Active
+              LbSegmentButtonItem(value="completed") Completed
+            p.demo-note Selected: {{ selectedSegment1 }}
+        
+        .demo-group
+          h4 Size Variants
+          .segment-demo
+            .segment-row
+              h5 Small
+              LbSegmentButton(v-model="selectedSize" size="small")
+                LbSegmentButtonItem(value="small") Small
+                LbSegmentButtonItem(value="medium") Medium
+                LbSegmentButtonItem(value="large") Large
+            
+            .segment-row
+              h5 Medium (Default)
+              LbSegmentButton(v-model="selectedSize")
+                LbSegmentButtonItem(value="small") Small
+                LbSegmentButtonItem(value="medium") Medium
+                LbSegmentButtonItem(value="large") Large
+            
+        
+        .demo-group
+          h4 Multi-Select Mode
+          .segment-demo
+            .segment-row
+              h5 Filter by Tags (Multi-select)
+              LbSegmentButton(v-model="selectedTags" :multiSelect="true")
+                LbSegmentButtonItem(value="vue") Vue.js
+                LbSegmentButtonItem(value="react") React
+                LbSegmentButtonItem(value="angular") Angular
+                LbSegmentButtonItem(value="svelte") Svelte
+              p.demo-note Selected: {{ selectedTags?.length ? selectedTags.join(', ') : 'None' }}
+            
+            .segment-row
+              h5 Toggle Mode (Single-select with deselect)
+              LbSegmentButton(v-model="toggleValue" :allowEmpty="true")
+                LbSegmentButtonItem(value="bold") Bold
+                LbSegmentButtonItem(value="italic") Italic
+                LbSegmentButtonItem(value="underline") Underline
+              p.demo-note Active: {{ toggleValue || 'None' }}
+        
+        .demo-group
+          h4 Width Variants
+          .segment-demo
+            .segment-row
+              h5 Full Width (Default - stretches to fill container)
+              LbSegmentButton(v-model="widthExample" width="full")
+                LbSegmentButtonItem(value="short") Short
+                LbSegmentButtonItem(value="medium-length") Medium Length
+                LbSegmentButtonItem(value="very-long-label") Very Long Label
+            
+            .segment-row
+              h5 Auto Width (Fits content)
+              LbSegmentButton(v-model="widthExample" width="auto")
+                LbSegmentButtonItem(value="short") Short
+                LbSegmentButtonItem(value="medium-length") Medium Length
+                LbSegmentButtonItem(value="very-long-label") Very Long Label
+            p.demo-note Auto width makes segments fit their content naturally
+        
+        .demo-group
+          h4 Color Variants
+          .segment-demo
+            .segment-row
+              h5 Primary (Default)
+              LbSegmentButton(v-model="colorExample" color="primary")
+                LbSegmentButtonItem(value="option1") Option 1
+                LbSegmentButtonItem(value="option2") Option 2
+                LbSegmentButtonItem(value="option3") Option 3
+            
+            .segment-row
+              h5 Secondary
+              LbSegmentButton(v-model="colorExample" color="secondary")
+                LbSegmentButtonItem(value="option1") Option 1
+                LbSegmentButtonItem(value="option2") Option 2
+                LbSegmentButtonItem(value="option3") Option 3
+                
+            .segment-row
+              h5 Neutral
+              LbSegmentButton(v-model="colorExample" color="neutral")
+                LbSegmentButtonItem(value="option1") Option 1
+                LbSegmentButtonItem(value="option2") Option 2
+                LbSegmentButtonItem(value="option3") Option 3
+            p.demo-note Colors provide subtle tonal variations for different contexts
+        
+        .demo-group
+          h4 With Icons
+          .segment-demo
+            LbSegmentButton(v-model="selectedView")
+              LbSegmentButtonItem(value="grid")
+                template(#icon)
+                  svg(width="18" height="18" viewBox="0 0 24 24" fill="currentColor")
+                    path(d="M3 3h8v8H3zm0 10h8v8H3zm10-10h8v8h-8zm0 10h8v8h-8z")
+                Grid
+              LbSegmentButtonItem(value="list")
+                template(#icon)
+                  svg(width="18" height="18" viewBox="0 0 24 24" fill="currentColor")
+                    path(d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z")
+                List
+              LbSegmentButtonItem(value="calendar")
+                template(#icon)
+                  svg(width="18" height="18" viewBox="0 0 24 24" fill="currentColor")
+                    path(d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z")
+                Calendar
+        
+        .demo-group
+          h4 Disabled States
+          .segment-demo
+            .segment-row
+              p Individual items disabled
+              LbSegmentButton(v-model="selectedDisabled")
+                LbSegmentButtonItem(value="option1") Option 1
+                LbSegmentButtonItem(value="option2" :disabled="true") Option 2
+                LbSegmentButtonItem(value="option3") Option 3
+                LbSegmentButtonItem(value="option4" :disabled="true") Option 4
+        
+        .demo-group
+          h4 Real-world Examples
+          .segment-demo
+            .example-card
+              h5 Content Filter
+              LbSegmentButton(v-model="contentFilter")
+                LbSegmentButtonItem(value="all") All
+                LbSegmentButtonItem(value="photos") Photos
+                LbSegmentButtonItem(value="videos") Videos
+                LbSegmentButtonItem(value="docs") Docs
+              
+              .content-preview
+                p(v-if="contentFilter === 'all'") Showing all 245 items
+                p(v-else-if="contentFilter === 'photos'") Showing 142 photos
+                p(v-else-if="contentFilter === 'videos'") Showing 67 videos
+                p(v-else-if="contentFilter === 'docs'") Showing 36 documents
+            
+            .example-card
+              h5 Date Range Selector
+              LbSegmentButton(v-model="dateRange" size="small")
+                LbSegmentButtonItem(value="today") Today
+                LbSegmentButtonItem(value="week") This Week
+                LbSegmentButtonItem(value="month") This Month
+                LbSegmentButtonItem(value="year") This Year
+              
+              .date-info
+                p(v-if="dateRange === 'today'") {{ new Date().toLocaleDateString() }}
+                p(v-else-if="dateRange === 'week'") Last 7 days
+                p(v-else-if="dateRange === 'month'") {{ new Date().toLocaleString('default', { month: 'long', year: 'numeric' }) }}
+                p(v-else-if="dateRange === 'year'") {{ new Date().getFullYear() }}
+                
+            .example-card
+              h5 Filter Options (Multi-select)
+              LbSegmentButton(v-model="statusFilters" :multiSelect="true" size="small" color="neutral")
+                LbSegmentButtonItem(value="active") Active
+                LbSegmentButtonItem(value="archived") Archived
+                LbSegmentButtonItem(value="starred") Starred
+              
+              .filter-info
+                p(v-if="!statusFilters || statusFilters.length === 0") Showing all items
+                p(v-else) Filters: {{ statusFilters.join(' + ') }}
 </template>
 
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { 
   LbButton, LbInput, LbLabel, LbHintText, LbTextarea, LbCheckbox, LbRadio, LbSwitch, LbSelect, LbFormField, LbDialog,
-  LbBadge, LbNavigationBar, LbNavigationBarItem, LbBottomSheet, LbChip, LbAvatar, LbProgress, LbDivider, useSnackbar
+  LbBadge, LbNavigationBar, LbNavigationBarItem, LbBottomSheet, LbChip, LbAvatar, LbProgress, LbDivider, 
+  LbSegmentButton, LbSegmentButtonItem, useSnackbar
 } from '../src'
 
 const isDark = ref(false)
@@ -2005,6 +2173,19 @@ const circularProgress2 = ref(85)
 const circularProgress3 = ref(60)
 const circularProgress4 = ref(75)
 const interactiveProgress = ref(50)
+
+// SegmentButton demo data
+const selectedSegment1 = ref(undefined) // Start with no selection
+const selectedSize = ref('medium')
+const selectedTags = ref([]) // Multi-select
+const toggleValue = ref(undefined) // Toggle mode
+const widthExample = ref('medium-length')
+const colorExample = ref('option2')
+const selectedView = ref('grid')
+const selectedDisabled = ref('option1')
+const contentFilter = ref('all')
+const dateRange = ref('month')
+const statusFilters = ref([])
 const tags = ref(['Vue.js', 'TypeScript', 'UI Kit', 'Component Library'])
 
 const activeFilters = computed(() => {
@@ -2614,6 +2795,55 @@ section
     h5
       margin: 0 0 base.$space-xs 0
       
+    p
+      margin: 0
+      color: var(--color-text-secondary)
+      font-size: var(--font-size-label-base)
+
+// SegmentButton demo styles
+.segment-demo
+  display: flex
+  flex-direction: column
+  gap: base.$space-lg
+  
+  .demo-note
+    margin-top: base.$space-sm
+    font-size: var(--font-size-label-base)
+    color: var(--color-text-secondary)
+
+.segment-row
+  display: flex
+  flex-direction: column
+  gap: base.$space-sm
+  
+  h5
+    margin: 0
+    color: var(--color-text-secondary)
+    font-size: var(--font-size-label-base)
+    text-transform: uppercase
+    letter-spacing: 0.05em
+
+.example-card
+  background: var(--color-surface)
+  border: base.$border-sm solid var(--color-border)
+  border-radius: base.$radius-md
+  padding: base.$space-lg
+  max-width: 500px
+  margin-bottom: base.$space-lg
+  
+  &:last-child
+    margin-bottom: 0
+  
+  h5
+    margin: 0 0 base.$space-md 0
+    
+  .content-preview,
+  .date-info
+    margin-top: base.$space-md
+    padding: base.$space-md
+    background: var(--color-surface-lowered)
+    border-radius: base.$radius-sm
+    
     p
       margin: 0
       color: var(--color-text-secondary)

--- a/src/components/Buttons/Button/LbButton.vue
+++ b/src/components/Buttons/Button/LbButton.vue
@@ -30,7 +30,7 @@ import { computed, useAttrs } from 'vue'
 
 // Types
 type Variant = 'filled' | 'tonal' | 'outline' | 'ghost' | 'link'
-type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'error' | 'info'
+type Color = 'primary' | 'secondary' | 'neutral' | 'success' | 'warning' | 'error' | 'info'
 type Size = 'small' | 'medium' | 'large'
 type ButtonType = 'button' | 'submit' | 'reset'
 

--- a/src/components/Buttons/SegmentButton/LbSegmentButton.vue
+++ b/src/components/Buttons/SegmentButton/LbSegmentButton.vue
@@ -1,0 +1,239 @@
+<template lang="pug">
+.lb-segment-button(
+  ref="segmentButtonRef"
+  :class="segmentButtonClasses" 
+  :role="multiSelect ? 'group' : (allowEmpty ? 'group' : 'radiogroup')" 
+  :aria-labelledby="ariaLabelledby"
+  tabindex="-1"
+)
+  slot
+</template>
+
+<script setup lang="ts">
+import { computed, provide, ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import type { Size, Width, Color } from './types'
+
+// Props
+const props = withDefaults(defineProps<{
+  modelValue?: string | number | string[] | number[]
+  size?: Size
+  width?: Width
+  color?: Color
+  disabled?: boolean
+  ariaLabelledby?: string
+  allowEmpty?: boolean  // Allow all segments to be unselected
+  multiSelect?: boolean  // Enable multi-select mode
+}>(), {
+  size: 'medium',
+  width: 'full',
+  color: 'primary',
+  disabled: false,
+  allowEmpty: true,
+  multiSelect: false
+})
+
+// Emits
+const emit = defineEmits<{
+  'update:modelValue': [value: string | number | string[] | number[] | undefined]
+}>()
+
+// Reactive state
+const activeValue = ref<string | number | string[] | number[] | undefined>(props.modelValue)
+const segmentButtonRef = ref<HTMLElement>()
+const segmentItems = ref<HTMLElement[]>([])
+
+// Watch for prop changes
+watch(() => props.modelValue, (newValue) => {
+  activeValue.value = newValue
+})
+
+// Computed
+const segmentButtonClasses = computed(() => {
+  const classes: any[] = [
+    `size-${props.size}`,
+    `width-${props.width}`,
+    `color-${props.color}`
+  ]
+  
+  if (props.disabled) {
+    classes.push('disabled')
+  }
+  
+  return classes
+})
+
+// Register segment item
+const registerSegmentItem = (element: HTMLElement) => {
+  if (!segmentItems.value.includes(element)) {
+    segmentItems.value.push(element)
+  }
+}
+
+// Unregister segment item
+const unregisterSegmentItem = (element: HTMLElement) => {
+  const index = segmentItems.value.indexOf(element)
+  if (index > -1) {
+    segmentItems.value.splice(index, 1)
+  }
+}
+
+// Get current focused index
+const getCurrentFocusedIndex = (): number => {
+  const activeElement = document.activeElement as HTMLElement
+  return segmentItems.value.findIndex(item => item === activeElement)
+}
+
+// Focus segment by index
+const focusSegmentByIndex = (index: number) => {
+  if (index >= 0 && index < segmentItems.value.length) {
+    segmentItems.value[index].focus()
+  }
+}
+
+// Keyboard navigation
+const handleKeydown = (event: KeyboardEvent) => {
+  if (props.disabled) return
+
+  const currentIndex = getCurrentFocusedIndex()
+  if (currentIndex === -1) return
+  
+  const itemsCount = segmentItems.value.length
+  if (itemsCount === 0) return
+
+  switch (event.key) {
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      event.preventDefault()
+      const prevIndex = currentIndex > 0 ? currentIndex - 1 : itemsCount - 1
+      focusSegmentByIndex(prevIndex)
+      break
+
+    case 'ArrowRight':
+    case 'ArrowDown':
+      event.preventDefault()
+      const nextIndex = currentIndex < itemsCount - 1 ? currentIndex + 1 : 0
+      focusSegmentByIndex(nextIndex)
+      break
+
+    case 'Home':
+      event.preventDefault()
+      focusSegmentByIndex(0)
+      break
+
+    case 'End':
+      event.preventDefault()
+      focusSegmentByIndex(itemsCount - 1)
+      break
+  }
+}
+
+// Update active value
+const updateActive = (value: string | number) => {
+  if (!props.disabled) {
+    if (props.multiSelect) {
+      // Multi-select mode
+      const currentValue = activeValue.value
+      let newValue: (string | number)[]
+      
+      if (Array.isArray(currentValue)) {
+        const index = currentValue.indexOf(value)
+        if (index > -1) {
+          // Remove if already selected
+          newValue = currentValue.filter(v => v !== value)
+        } else {
+          // Add if not selected
+          newValue = [...currentValue, value]
+        }
+      } else if (currentValue === value) {
+        // If current value is the single value being toggled, remove it
+        newValue = []
+      } else if (currentValue !== undefined) {
+        // Convert single value to array and add new value
+        newValue = [currentValue, value]
+      } else {
+        // Initialize as array with first value
+        newValue = [value]
+      }
+      
+      activeValue.value = newValue
+      emit('update:modelValue', newValue)
+    } else {
+      // Single-select mode
+      if (props.allowEmpty && activeValue.value === value) {
+        activeValue.value = undefined
+        emit('update:modelValue', undefined)
+      } else {
+        activeValue.value = value
+        emit('update:modelValue', value)
+      }
+    }
+  }
+}
+
+// Provide context to child items
+provide('segmentButton', {
+  activeValue,
+  size: computed(() => props.size),
+  color: computed(() => props.color),
+  disabled: computed(() => props.disabled),
+  allowEmpty: computed(() => props.allowEmpty),
+  multiSelect: computed(() => props.multiSelect),
+  updateActive,
+  registerSegmentItem,
+  unregisterSegmentItem
+})
+
+// Mount keyboard listener
+onMounted(() => {
+  nextTick(() => {
+    if (segmentButtonRef.value) {
+      segmentButtonRef.value.addEventListener('keydown', handleKeydown)
+    }
+  })
+})
+
+// Cleanup on unmount
+onUnmounted(() => {
+  if (segmentButtonRef.value) {
+    segmentButtonRef.value.removeEventListener('keydown', handleKeydown)
+  }
+})
+
+// Component options
+defineOptions({
+  name: 'LbSegmentButton',
+  inheritAttrs: false
+})
+</script>
+
+<style lang="sass" scoped>
+@use '@/styles/base' as base
+
+.lb-segment-button
+  display: inline-grid
+  grid-auto-flow: column
+  gap: 0
+  position: relative
+  border: base.$border-sm solid var(--color-border-strong)
+  border-radius: base.$radius-full
+  overflow: hidden
+  
+  // Width variants
+  &.width-full
+    width: 100%
+    grid-auto-columns: 1fr
+    
+  &.width-auto
+    width: max-content
+    grid-auto-columns: minmax(max-content, 1fr)
+
+  &.size-small
+    height: base.$size-5xl // 32px
+    
+  &.size-medium
+    height: base.$size-6xl // 40px
+
+  &.disabled
+    opacity: base.$opacity-60
+    pointer-events: none
+</style>

--- a/src/components/Buttons/SegmentButton/LbSegmentButtonItem.vue
+++ b/src/components/Buttons/SegmentButton/LbSegmentButtonItem.vue
@@ -1,0 +1,236 @@
+<template lang="pug">
+button.lb-segment-button-item(
+  ref="itemRef"
+  :class="itemClasses"
+  :disabled="isDisabled"
+  :aria-pressed="(segmentButton.allowEmpty.value || segmentButton.multiSelect.value) ? isActive : undefined"
+  :aria-label="ariaLabel"
+  @click="handleClick"
+  type="button"
+  :role="(segmentButton.allowEmpty.value || segmentButton.multiSelect.value) ? 'button' : 'radio'"
+  :aria-checked="(segmentButton.allowEmpty.value || segmentButton.multiSelect.value) ? undefined : isActive"
+)
+  span.icon-container(v-if="slots.icon")
+    slot(name="icon")
+  
+  span.label(v-if="slots.default")
+    slot
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref, onMounted, onUnmounted, useSlots } from 'vue'
+import type { SegmentButtonContext } from './types'
+
+// Props
+const props = withDefaults(defineProps<{
+  value: string | number
+  disabled?: boolean
+  ariaLabel?: string
+}>(), {
+  disabled: false
+})
+
+// Slots
+const slots = useSlots()
+
+// Refs
+const itemRef = ref<HTMLButtonElement>()
+
+// Inject context from parent SegmentButton
+const injectedContext = inject<SegmentButtonContext>('segmentButton')
+
+// This should never happen in practice since the component is only used inside SegmentButton
+if (!injectedContext) {
+  throw new Error('LbSegmentButtonItem must be used inside LbSegmentButton')
+}
+
+// Now TypeScript knows segmentButton is not null
+const segmentButton = injectedContext
+
+// Computed
+const isActive = computed(() => {
+  const activeValue = segmentButton.activeValue.value
+  if (Array.isArray(activeValue)) {
+    return activeValue.includes(props.value)
+  }
+  return activeValue === props.value
+})
+
+const isDisabled = computed(() => 
+  props.disabled || segmentButton.disabled.value
+)
+
+const itemClasses = computed(() => {
+  const classes: any[] = [
+    `size-${segmentButton.size.value}`,
+    `color-${segmentButton.color.value}`
+  ]
+  
+  if (isActive.value) classes.push('active')
+  if (isDisabled.value) classes.push('disabled')
+  if (!!slots.icon) classes.push('has-icon')
+  if (!!slots.icon && !slots.default) classes.push('icon-only')
+  if (!slots.icon && !!slots.default) classes.push('text-only')
+  
+  return classes
+})
+
+// Methods
+const handleClick = () => {
+  if (!isDisabled.value) {
+    segmentButton.updateActive(props.value)
+  }
+}
+
+// Register/unregister with parent
+onMounted(() => {
+  if (itemRef.value) {
+    segmentButton.registerSegmentItem(itemRef.value)
+  }
+})
+
+onUnmounted(() => {
+  if (itemRef.value) {
+    segmentButton.unregisterSegmentItem(itemRef.value)
+  }
+})
+
+// Component options
+defineOptions({
+  name: 'LbSegmentButtonItem',
+  inheritAttrs: false
+})
+</script>
+
+<style lang="sass" scoped>
+@use '@/styles/base' as base
+
+.lb-segment-button-item
+  display: flex
+  align-items: center
+  justify-content: center
+  gap: base.$space-sm // 8px
+  height: 100%
+  width: 100%
+  padding: 0 base.$space-lg // 16px minimum padding
+  background: transparent
+  border: none
+  border-radius: 0
+  user-select: none
+  
+  // Add left border divider for non-first items
+  &:not(:first-child)
+    border-left: base.$border-sm solid var(--color-border-strong)
+  cursor: pointer
+  transition: all base.$transition
+  color: var(--color-text-secondary)
+  font-size: var(--font-size-base)
+  font-weight: var(--font-weight-medium)
+  line-height: var(--line-height-compact)
+  outline: none
+  position: relative
+  white-space: nowrap
+  
+  &:focus-visible
+    outline: base.$focus-ring-width solid var(--color-focus-ring)
+    outline-offset: base.$focus-ring-offset
+    z-index: 2
+
+  // Hover states for each color variant
+  @media (hover: hover)
+    &:hover:not(.disabled):not(.active)
+      &.color-primary
+        background-color: var(--color-primary-3)
+      &.color-secondary
+        background-color: var(--color-secondary-3)
+      &.color-neutral
+        background-color: var(--color-neutral-3)
+
+
+  &.disabled
+    opacity: base.$opacity-40
+    cursor: not-allowed
+
+  // Active state - Primary color variant (default)
+  &.color-primary.active
+    background: var(--color-primary-4)
+    color: var(--color-primary-11)
+    z-index: 1
+
+    @media (hover: hover)
+      &:hover:not(.disabled)
+        background: var(--color-primary-5)
+        
+  // Active state - Secondary color variant
+  &.color-secondary.active
+    background: var(--color-secondary-4)
+    color: var(--color-secondary-11)
+    z-index: 1
+
+    @media (hover: hover)
+      &:hover:not(.disabled)
+        background: var(--color-secondary-5)
+        
+  // Active state - Neutral color variant
+  &.color-neutral.active
+    background: var(--color-neutral-4)
+    color: var(--color-neutral-11)
+    z-index: 1
+
+    @media (hover: hover)
+      &:hover:not(.disabled)
+        background: var(--color-neutral-5)
+
+  // Size variants
+  &.size-small
+    padding: 0 base.$space-lg // 16px minimum
+    font-size: var(--font-size-sm)
+    
+    .icon-container
+      width: base.$size-3xl
+      height: base.$size-3xl
+      
+      :deep(svg)
+        width: base.$size-3xl
+        height: base.$size-3xl
+
+  &.size-medium
+    padding: 0 base.$space-lg // 16px minimum
+    font-size: var(--font-size-base)
+    
+    .icon-container
+      width: base.$size-4xl
+      height: base.$size-4xl
+      
+      :deep(svg)
+        width: base.$size-4xl
+        height: base.$size-4xl
+
+
+  // Icon and text layout
+  .icon-container
+    display: flex
+    align-items: center
+    justify-content: center
+    transition: all base.$transition
+
+  .label
+    transition: color base.$transition
+    text-overflow: ellipsis
+    overflow: hidden
+
+  // Icon-only styling
+  &.icon-only
+    gap: 0
+    
+    &.size-small
+      min-width: base.$size-5xl // 32px
+      padding: 0
+    
+    &.size-medium
+      min-width: base.$size-6xl // 40px
+      padding: 0
+    
+
+
+</style>

--- a/src/components/Buttons/SegmentButton/index.ts
+++ b/src/components/Buttons/SegmentButton/index.ts
@@ -1,0 +1,3 @@
+export { default as LbSegmentButton } from './LbSegmentButton.vue'
+export { default as LbSegmentButtonItem } from './LbSegmentButtonItem.vue'
+export type { Size, Width, Color, SegmentButtonContext } from './types'

--- a/src/components/Buttons/SegmentButton/types.ts
+++ b/src/components/Buttons/SegmentButton/types.ts
@@ -1,0 +1,18 @@
+import type { ComputedRef, Ref } from 'vue'
+
+// SegmentButton shared types
+export type Size = 'small' | 'medium'
+export type Width = 'full' | 'auto'
+export type Color = 'primary' | 'secondary' | 'neutral'
+
+export interface SegmentButtonContext {
+  activeValue: Ref<string | number | string[] | number[] | undefined>
+  size: ComputedRef<Size>
+  color: ComputedRef<Color>
+  disabled: ComputedRef<boolean>
+  allowEmpty: ComputedRef<boolean>
+  multiSelect: ComputedRef<boolean>
+  updateActive: (value: string | number) => void
+  registerSegmentItem: (element: HTMLElement) => void
+  unregisterSegmentItem: (element: HTMLElement) => void
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as LbAvatar } from './Avatar'
 export { default as LbBadge } from './Badge'
 export { default as LbButton } from './Buttons/Button'
+export { LbSegmentButton, LbSegmentButtonItem } from './Buttons/SegmentButton'
 export { default as LbChip } from './Chip'
 export { default as LbDivider } from './Divider'
 export { default as LbInput } from './Input'

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import './styles/index.sass'
 import LbAvatar from './components/Avatar'
 import LbBadge from './components/Badge'
 import LbButton from './components/Buttons/Button'
+import { LbSegmentButton, LbSegmentButtonItem } from './components/Buttons/SegmentButton'
 import LbChip from './components/Chip'
 import LbDivider from './components/Divider'
 import LbInput from './components/Input'
@@ -25,7 +26,7 @@ import LbProgress from './components/Progress'
 import { LbSnackbar, LbSnackbarProvider, useSnackbar, createSnackbarHelpers } from './components/Snackbar'
 
 // Export individual components for tree-shaking
-export { LbAvatar, LbBadge, LbButton, LbChip, LbDivider, LbInput, LbLabel, LbHintText, LbTextarea, LbCheckbox, LbRadio, LbSwitch, LbSelect, LbFormField, LbDialog, LbBottomSheet, LbNavigationBar, LbNavigationBarItem, LbProgress, LbSnackbar, LbSnackbarProvider, useSnackbar, createSnackbarHelpers }
+export { LbAvatar, LbBadge, LbButton, LbSegmentButton, LbSegmentButtonItem, LbChip, LbDivider, LbInput, LbLabel, LbHintText, LbTextarea, LbCheckbox, LbRadio, LbSwitch, LbSelect, LbFormField, LbDialog, LbBottomSheet, LbNavigationBar, LbNavigationBarItem, LbProgress, LbSnackbar, LbSnackbarProvider, useSnackbar, createSnackbarHelpers }
 
 // Plugin install function for Vue.use()
 const LittleBrandUI = {
@@ -34,6 +35,8 @@ const LittleBrandUI = {
     app.component('LbAvatar', LbAvatar)
     app.component('LbBadge', LbBadge)
     app.component('LbButton', LbButton)
+    app.component('LbSegmentButton', LbSegmentButton)
+    app.component('LbSegmentButtonItem', LbSegmentButtonItem)
     app.component('LbChip', LbChip)
     app.component('LbDivider', LbDivider)
     app.component('LbInput', LbInput)

--- a/src/styles/_themes.sass
+++ b/src/styles/_themes.sass
@@ -51,6 +51,27 @@
   --color-secondary-a4: #{colors.$teal-a4}
   --color-secondary-a5: #{colors.$teal-a5}
   
+  // Neutral (using gray scale)
+  --color-neutral: #{colors.$gray-9}
+  --color-neutral-hover: #{colors.$gray-10}
+  --color-neutral-active: #{colors.$gray-11}
+  --color-neutral-subtle: #{colors.$gray-4}
+  --color-neutral-text: #{colors.$gray-12}
+  // Interactive states (following Radix UI pattern)
+  --color-neutral-3: #{colors.$gray-3}
+  --color-neutral-4: #{colors.$gray-4}
+  --color-neutral-5: #{colors.$gray-5}
+  --color-neutral-6: #{colors.$gray-6}
+  --color-neutral-7: #{colors.$gray-7}
+  --color-neutral-8: #{colors.$gray-8}
+  --color-neutral-9: #{colors.$gray-9}
+  --color-neutral-10: #{colors.$gray-10}
+  --color-neutral-11: #{colors.$gray-11}
+  --color-neutral-12: #{colors.$gray-12}
+  --color-neutral-a3: #{colors.$gray-a3}
+  --color-neutral-a4: #{colors.$gray-a4}
+  --color-neutral-a5: #{colors.$gray-a5}
+  
   // === State Colors ===
   // Error
   --color-error: #{colors.$red-9}
@@ -304,6 +325,27 @@
   --color-secondary-a3: #{colors.$teal-dark-a3}
   --color-secondary-a4: #{colors.$teal-dark-a4}
   --color-secondary-a5: #{colors.$teal-dark-a5}
+  
+  // Neutral (using gray scale)
+  --color-neutral: #{colors.$gray-dark-9}
+  --color-neutral-hover: #{colors.$gray-dark-10}
+  --color-neutral-active: #{colors.$gray-dark-11}
+  --color-neutral-subtle: #{colors.$gray-dark-4}
+  --color-neutral-text: #{colors.$gray-dark-12}
+  // Interactive states (following Radix UI pattern)
+  --color-neutral-3: #{colors.$gray-dark-3}
+  --color-neutral-4: #{colors.$gray-dark-4}
+  --color-neutral-5: #{colors.$gray-dark-5}
+  --color-neutral-6: #{colors.$gray-dark-6}
+  --color-neutral-7: #{colors.$gray-dark-7}
+  --color-neutral-8: #{colors.$gray-dark-8}
+  --color-neutral-9: #{colors.$gray-dark-9}
+  --color-neutral-10: #{colors.$gray-dark-10}
+  --color-neutral-11: #{colors.$gray-dark-11}
+  --color-neutral-12: #{colors.$gray-dark-12}
+  --color-neutral-a3: #{colors.$gray-dark-a3}
+  --color-neutral-a4: #{colors.$gray-dark-a4}
+  --color-neutral-a5: #{colors.$gray-dark-a5}
   
   // === State Colors ===
   // Error

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,10 @@ export default defineConfig({
           pug: {
             doctype: 'html'
           }
+        },
+        compilerOptions: {
+          // Tell Vue to treat these as custom elements and not try to resolve them as components
+          isCustomElement: (tag) => ['Calendar', 'Grid', 'List'].includes(tag)
         }
       }
     })


### PR DESCRIPTION
- Create SegmentButton component with single/multi-select modes
- Implement Material Design 3 connected segment style with full outer radius
- Add toggleable segments with allowEmpty prop
- Support width variants (full/auto) and size variants (small/medium)
- Add color variants (primary, secondary, neutral) following RadixUI pattern
- Add neutral color variables to theme (levels 3-12) for both light and dark modes
- Fix hover state persistence on mobile with @media (hover: hover)
- Implement proper TypeScript types with Vue ref support
- Add keyboard navigation (arrow keys, home/end)
- Fix Vue component resolution warnings for custom elements
- Update Button component to support neutral color variant

🤖 Generated with [Claude Code](https://claude.ai/code)