### PR TITLE
chore: bump version to 0.2.6 for documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.5] - 2024-01-25
+## [0.2.6] - 2025-01-25
+
+### Changed
+- **Documentation**
+  - Updated README.md with comprehensive documentation section
+  - Added links to all customization guides and references
+  - Clarified that dark mode is opt-in by default
+
+## [0.2.5] - 2025-01-25
 
 ### Added
 - **Typography System Improvements**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littlebrand-ui-kit",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Clean, semantic Vue.js UI kit using Pug & SASS. Zero utility classes, CSS Grid-first, fully themeable.",
   "type": "module",
   "files": [


### PR DESCRIPTION
- Updated package.json version from 0.2.5 to 0.2.6
- Added CHANGELOG entry for documentation improvements
- Required for NPM publish to update README on npmjs.com

🤖 Generated with [Claude Code](https://claude.ai/code)