### PR TITLE
fix: resolve font weight override issues and expand weight scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2025-08-26
+
+### Fixed
+- **Font Weight Variable Override Issue**
+  - Fixed unified font weight variables using `var()` references that prevented proper overriding in external projects
+  - Changed `--lb-font-weight-heading`, `--lb-font-weight-body`, and `--lb-font-weight-label` to use direct numeric values (600, 400, 500)
+  - Removed duplicate typography variable definitions from dark theme (typography doesn't change between themes)
+
+### Changed
+- **Typography System**
+  - Expanded font weight scale from 4 weights to full CSS standard 9-weight scale (100-900)
+  - Renamed `--lb-font-weight-normal` to `--lb-font-weight-regular` for clarity and consistency
+  - Added new font weights: thin (100), extralight (200), light (300), extrabold (800), black (900)
+  - Updated all SASS variables to match the new naming convention
+
+### Updated
+- **Documentation & Type Definitions**
+  - Updated `littlebrand-overrides-template.sass` with full font weight scale
+  - Updated TypeScript definitions in `littlebrand.css.d.ts` with all 9 font weights
+  - Updated `TYPOGRAPHY_CUSTOMIZATION_GUIDE.md` with new font weight variables
+  - Updated `CSS_VARIABLES_REFERENCE.md` with complete weight scale
+  - Updated README.md to use `--lb-font-weight-regular` instead of `--lb-font-weight-normal`
+
 ## [0.2.6] - 2025-01-25
 
 ### Changed

--- a/CSS_VARIABLES_REFERENCE.md
+++ b/CSS_VARIABLES_REFERENCE.md
@@ -328,11 +328,16 @@ Text colors for use on filled backgrounds (ensures proper contrast).
 ### Font Weights
 
 ```css
-/* Individual weight values */
---lb-font-weight-normal      /* 400 */
+/* Full font weight scale */
+--lb-font-weight-thin        /* 100 */
+--lb-font-weight-extralight  /* 200 */
+--lb-font-weight-light       /* 300 */
+--lb-font-weight-regular     /* 400 */
 --lb-font-weight-medium      /* 500 */
 --lb-font-weight-semibold    /* 600 */
 --lb-font-weight-bold        /* 700 */
+--lb-font-weight-extrabold   /* 800 */
+--lb-font-weight-black       /* 900 */
 
 /* Unified weights for easy customization */
 --lb-font-weight-heading     /* Weight for all headings */

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ applyTheme({
   --lb-font-size-sm: 13px;
   --lb-font-size-base: 15px;
   --lb-font-size-lg: 18px;
-  --lb-font-weight-normal: 400;
+  --lb-font-weight-regular: 400;
   --lb-font-weight-medium: 500;
   --lb-font-weight-bold: 700;
   

--- a/TYPOGRAPHY_CUSTOMIZATION_GUIDE.md
+++ b/TYPOGRAPHY_CUSTOMIZATION_GUIDE.md
@@ -22,11 +22,16 @@ The UI kit provides these main typography variables that you can override:
   --lb-font-weight-body: 400;     /* Controls paragraph/body text weight */
   --lb-font-weight-label: 500;    /* Controls form labels and UI text weight */
   
-  /* Individual Weight Values (if you need fine control) */
-  --lb-font-weight-normal: 400;
+  /* Full Font Weight Scale */
+  --lb-font-weight-thin: 100;
+  --lb-font-weight-extralight: 200;
+  --lb-font-weight-light: 300;
+  --lb-font-weight-regular: 400;
   --lb-font-weight-medium: 500;
   --lb-font-weight-semibold: 600;
   --lb-font-weight-bold: 700;
+  --lb-font-weight-extrabold: 800;
+  --lb-font-weight-black: 900;
 }
 ```
 

--- a/littlebrand-overrides-template.sass
+++ b/littlebrand-overrides-template.sass
@@ -50,15 +50,20 @@
   // --lb-font-mono: 'Your Mono Font', monospace
   
   // Unified Font Weights (recommended - controls all at once)
-  // --lb-font-weight-heading: 600    // All headings
-  // --lb-font-weight-body: 400       // All body text
-  // --lb-font-weight-label: 500      // All labels/UI text
+  // --lb-font-weight-heading: 600
+  // --lb-font-weight-body: 400
+  // --lb-font-weight-label: 500
   
-  // Individual Weight Values (for fine control)
-  // --lb-font-weight-normal: 400
+  // Full Font Weight Scale
+  // --lb-font-weight-thin: 100
+  // --lb-font-weight-extralight: 200
+  // --lb-font-weight-light: 300
+  // --lb-font-weight-regular: 400
   // --lb-font-weight-medium: 500
   // --lb-font-weight-semibold: 600
   // --lb-font-weight-bold: 700
+  // --lb-font-weight-extrabold: 800
+  // --lb-font-weight-black: 900
   
   // Line Heights
   // --lb-line-height-tight: 1.1

--- a/littlebrand.css.d.ts
+++ b/littlebrand.css.d.ts
@@ -30,14 +30,24 @@ declare module 'csstype' {
     /** Unified font weight for labels and UI text (default: 500) */
     '--lb-font-weight-label'?: number | string;
     
-    /** Normal font weight (400) */
-    '--lb-font-weight-normal'?: number | string;
+    /** Thin font weight (100) */
+    '--lb-font-weight-thin'?: number | string;
+    /** Extra light font weight (200) */
+    '--lb-font-weight-extralight'?: number | string;
+    /** Light font weight (300) */
+    '--lb-font-weight-light'?: number | string;
+    /** Regular font weight (400) */
+    '--lb-font-weight-regular'?: number | string;
     /** Medium font weight (500) */
     '--lb-font-weight-medium'?: number | string;
     /** Semibold font weight (600) */
     '--lb-font-weight-semibold'?: number | string;
     /** Bold font weight (700) */
     '--lb-font-weight-bold'?: number | string;
+    /** Extra bold font weight (800) */
+    '--lb-font-weight-extrabold'?: number | string;
+    /** Black font weight (900) */
+    '--lb-font-weight-black'?: number | string;
     
     /** Tight line height (1.1) */
     '--lb-line-height-tight'?: number | string;

--- a/src/styles/_theme.sass
+++ b/src/styles/_theme.sass
@@ -341,15 +341,20 @@ $use-custom-theme: false !default
   --lb-font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace
   
   // Font weights
-  --lb-font-weight-normal: 400
+  --lb-font-weight-thin: 100
+  --lb-font-weight-extralight: 200
+  --lb-font-weight-light: 300
+  --lb-font-weight-regular: 400
   --lb-font-weight-medium: 500
   --lb-font-weight-semibold: 600
   --lb-font-weight-bold: 700
+  --lb-font-weight-extrabold: 800
+  --lb-font-weight-black: 900
   
   // Unified font weights for easy customization
-  --lb-font-weight-heading: var(--lb-font-weight-semibold)
-  --lb-font-weight-body: var(--lb-font-weight-normal)
-  --lb-font-weight-label: var(--lb-font-weight-medium)
+  --lb-font-weight-heading: 600
+  --lb-font-weight-body: 400
+  --lb-font-weight-label: 500
   
   // Line heights
   --lb-line-height-tight: 1.1
@@ -648,47 +653,3 @@ $use-custom-theme: false !default
     // === ADDITIONAL TOKENS ===
     --lb-focus-ring-color: #{colors.$orange-dark-a7}
     --lb-divider-color: var(--lb-border-neutral-line)
-    
-    // === TYPOGRAPHY TOKENS (same in dark mode) ===
-    // Font families
-    --lb-font-heading: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif
-    --lb-font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif
-    --lb-font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace
-    
-    // Font weights
-    --lb-font-weight-normal: 400
-    --lb-font-weight-medium: 500
-    --lb-font-weight-semibold: 600
-    --lb-font-weight-bold: 700
-    
-    // Unified font weights for easy customization
-    --lb-font-weight-heading: var(--lb-font-weight-semibold)
-    --lb-font-weight-body: var(--lb-font-weight-normal)
-    --lb-font-weight-label: var(--lb-font-weight-medium)
-    
-    // Line heights
-    --lb-line-height-tight: 1.1
-    --lb-line-height-compact: 1.25
-    --lb-line-height-normal: 1.5
-    --lb-line-height-relaxed: 1.75
-    
-    // Font sizes - Body text (for content)
-    --lb-font-size-body-small: 0.875rem
-    --lb-font-size-body-base: 1rem
-    --lb-font-size-body-large: 1.125rem
-    
-    // Font sizes - Labels (for UI elements)
-    --lb-font-size-label-xsmall: 0.625rem
-    --lb-font-size-label-small: 0.75rem
-    --lb-font-size-label-base: 0.875rem
-    --lb-font-size-label-large: 1rem
-    
-    // Letter spacing
-    --lb-letter-spacing-tighter: -0.025em
-    --lb-letter-spacing-tight: -0.01em
-    --lb-letter-spacing-normal: normal
-    --lb-letter-spacing-wide: 0.025em
-    
-    // Display sizes (for hero sections, etc.)
-    --lb-display-1: clamp(3rem, 5vw + 1rem, 5rem)
-    --lb-display-2: clamp(2.5rem, 4vw + 1rem, 4rem)

--- a/src/styles/_typography.sass
+++ b/src/styles/_typography.sass
@@ -27,10 +27,15 @@ $font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, san
 $font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace !default
 
 // Font weights
-$font-weight-normal: 400 !default
+$font-weight-thin: 100 !default
+$font-weight-extralight: 200 !default
+$font-weight-light: 300 !default
+$font-weight-regular: 400 !default
 $font-weight-medium: 500 !default
 $font-weight-semibold: 600 !default
 $font-weight-bold: 700 !default
+$font-weight-extrabold: 800 !default
+$font-weight-black: 900 !default
 
 // Line heights
 $line-height-tight: 1.1 !default


### PR DESCRIPTION
- Fixed unified font weight variables using var() references preventing overrides
- Expanded font weight scale to full CSS standard (100-900)
- Renamed --lb-font-weight-normal to --lb-font-weight-regular
- Removed duplicate typography definitions from dark theme
- Updated all documentation and type definitions

🤖 Generated with [Claude Code](https://claude.ai/code)