### PR TITLE
fix: improve responsive behavior for dialogs and bottom sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.9] - 2025-08-27
+
+### Fixed
+- **Responsive Layout Issues**
+  - Fixed overflow in Font Weight Testing section by adding `flex-wrap` to control buttons
+  - Improved Dialog component responsiveness by using `width: min(dialog-width-medium, 90%)` instead of complex calc()
+  - Removed unnecessary media query overrides in Dialog component
+  - Changed BottomSheet default maxHeight from `80vh` to `80dvh` to prevent jumping when mobile address bar toggles
+  - Added fallback for browsers that don't support dvh units
+
+## [0.2.8] - 2025-08-27
 
 ### Fixed
 - **Font Weight CSS Variable Implementation**

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -3830,6 +3830,7 @@ section
     
     .control-buttons
       display: flex
+      flex-wrap: wrap
       gap: base.$space-sm
       margin-top: base.$space-lg
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littlebrand-ui-kit",
-  "version": "0.2.7",
+  "version": "0.2.9",
   "description": "Clean, semantic Vue.js UI kit using Pug & SASS. Zero utility classes, CSS Grid-first, fully themeable.",
   "type": "module",
   "files": [

--- a/src/components/BottomSheet/LbBottomSheet.vue
+++ b/src/components/BottomSheet/LbBottomSheet.vue
@@ -65,7 +65,7 @@ export interface LbBottomSheetProps {
 // Props
 const props = withDefaults(defineProps<LbBottomSheetProps>(), {
   modelValue: false,
-  maxHeight: '80vh',
+  maxHeight: '80dvh',
   expandable: true,
   swipeable: true,
   showHandle: true,
@@ -539,6 +539,7 @@ defineExpose({
   padding-bottom: env(safe-area-inset-bottom)
   
   &.state-expanded
+    max-height: 100vh // Fallback for browsers that don't support dvh
     max-height: 100dvh
     max-height: calc(100dvh - env(safe-area-inset-top, 0px))
     border-radius: 0

--- a/src/components/Dialog/LbDialog.vue
+++ b/src/components/Dialog/LbDialog.vue
@@ -280,16 +280,10 @@ defineExpose({
   background: var(--lb-background-surface)
   border-radius: cv.$dialog-border-radius
   box-shadow: base.$shadow-lg
-  max-width: min(calc(100vw - 2 * base.$space-lg), cv.$dialog-width-medium)
-  width: 100%
+  width: min(cv.$dialog-width-medium, 90%)
   max-height: min(90vh, 48rem)
   display: flex
   flex-direction: column
-  
-  // Ensure it doesn't overflow on mobile
-  @media (max-width: 640px)
-    max-width: calc(100vw - 2 * base.$space-lg)
-    max-height: calc(100vh - 2 * base.$space-lg)
   
   // Full-screen variant
   &.variant-fullscreen
@@ -377,9 +371,6 @@ defineExpose({
 @media (max-width: 640px)
   .lb-dialog-overlay
     padding: base.$space-lg
-    
-  .lb-dialog
-    max-width: 100%
     
   .dialog-header,
   .dialog-content,


### PR DESCRIPTION
- Add flex-wrap to control buttons in examples to prevent overflow
- Update dialog width to use min() function for better responsiveness
- Change bottom sheet maxHeight to use dvh units to prevent mobile viewport jumping
- Remove unnecessary media query overrides in dialog component
- Bump version to 0.2.9

🤖 Generated with [Claude Code](https://claude.ai/code)