### PR TITLE
fix: improve OKLCH contrast calculation for text-on-color tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-08-28
+
+### Fixed
+- **OKLCH Contrast Calculation Algorithm**
+  - Fixed incorrect text color selection on filled buttons across all color variants
+  - Raised contrast threshold from 0.6 to 0.75 for better OKLCH lightness evaluation
+  - Added special handling for warning/yellow colors that require dark text at lower lightness values (>0.65)
+  - Primary buttons now correctly display white text on dark orange backgrounds (was incorrectly showing black)
+  - All other dark filled buttons (secondary, success, error, info, neutral) maintain proper white text
+  - Warning buttons correctly keep dark text for accessibility on yellow backgrounds
+  - Eliminated the need for manual `--lb-text-on-primary` overrides in user projects
+  - Ensured consistency between static theme defaults and dynamic color generation
+
 ## [0.3.1] - 2025-08-28
 
 ### Improved

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littlebrand-ui-kit",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Clean, semantic Vue.js UI kit using Pug & SASS. Zero utility classes, CSS Grid-first, fully themeable.",
   "type": "module",
   "files": [

--- a/src/utils/color-generator.js
+++ b/src/utils/color-generator.js
@@ -64,7 +64,19 @@ export function generateSemanticTokens(name, scale, darkScale = null) {
   // Parse OKLCH lightness from scale[9]
   const match = scale[9].match(/oklch\(([\d.]+)/)
   const lightness = match ? parseFloat(match[1]) : 0.5
-  const textColor = lightness > 0.6 ? 'var(--lb-text-neutral-contrast-high)' : 'white'
+  
+  // Improved OKLCH contrast calculation
+  // Most colors at 0.75+ lightness need dark text, but yellow is special case
+  let textColor = 'white' // Default to white for most colors
+  
+  if (lightness > 0.75) {
+    // High lightness usually needs dark text
+    textColor = 'var(--lb-text-neutral-contrast-high)'
+  } else if (lightness > 0.65 && name === 'warning') {
+    // Yellow/warning colors need dark text even at lower lightness
+    textColor = 'var(--lb-text-neutral-contrast-high)'
+  }
+  // All other cases default to white text
   
   tokens[`--lb-text-on-${name}`] = textColor
   tokens[`--lb-text-on-${name}-hover`] = textColor


### PR DESCRIPTION
Fixed incorrect text color selection on filled buttons across all color variants. The OKLCH contrast algorithm was using too low a threshold (0.6) causing primary buttons to incorrectly display black text on dark orange backgrounds.

Changes:
- Raised contrast threshold from 0.6 to 0.75 for better OKLCH lightness evaluation
- Added special handling for warning/yellow colors (>0.65 lightness)
- Primary buttons now correctly display white text
- All dark filled buttons maintain proper white text contrast
- Warning buttons correctly keep dark text for accessibility

This eliminates the need for manual --lb-text-on-primary overrides in user projects.

🤖 Generated with [Claude Code](https://claude.ai/code)