### PR TITLE
feat: add dedicated --lb-font-label CSS variable for UI typography

### DIFF
--- a/littlebrand-overrides-template.sass
+++ b/littlebrand-overrides-template.sass
@@ -47,6 +47,7 @@
   // Font Families
   // --lb-font-heading: 'Your Font', sans-serif
   // --lb-font-body: 'Your Font', sans-serif
+  // --lb-font-label: 'Your Font', sans-serif
   // --lb-font-mono: 'Your Mono Font', monospace
   
   // Unified Font Weights (recommended - controls all at once)

--- a/src/components/Avatar/LbAvatar.vue
+++ b/src/components/Avatar/LbAvatar.vue
@@ -214,7 +214,7 @@ defineOptions({
 
     // Fallback text inside
     .fallback-text
-      font-family: typography.$font-body
+      font-family: var(--lb-font-label)
       text-transform: uppercase
       letter-spacing: typography.$letter-spacing-wide
       line-height: typography.$line-height-compact

--- a/src/components/Badge/LbBadge.vue
+++ b/src/components/Badge/LbBadge.vue
@@ -105,7 +105,7 @@ defineOptions({
   display: inline-flex
   align-items: center
   justify-content: center
-  font-family: typography.$font-body
+  font-family: var(--lb-font-label)
   font-weight: var(--lb-font-weight-semibold)
   line-height: 1
   letter-spacing: typography.$letter-spacing-tight

--- a/src/components/Buttons/Button/LbButton.vue
+++ b/src/components/Buttons/Button/LbButton.vue
@@ -136,7 +136,7 @@ defineOptions({
   height: cv.$button-height-medium  // Default to medium
   border: none
   border-radius: cv.$button-border-radius
-  font-family: typography.$font-body
+  font-family: var(--lb-font-label)
   font-size: cv.$button-font-size-medium
   font-weight: var(--lb-font-weight-label)
   line-height: typography.$line-height-normal

--- a/src/components/Chip/LbChip.vue
+++ b/src/components/Chip/LbChip.vue
@@ -141,7 +141,7 @@ defineOptions({
   gap: base.$space-xs
   border: base.$border-sm solid var(--lb-border-neutral-line)
   border-radius: cv.$chip-border-radius
-  font-family: typography.$font-body
+  font-family: var(--lb-font-label)
   font-weight: var(--lb-font-weight-label)
   line-height: typography.$line-height-compact
   letter-spacing: typography.$letter-spacing-tight

--- a/src/components/HintText/LbHintText.vue
+++ b/src/components/HintText/LbHintText.vue
@@ -45,6 +45,7 @@ defineSlots<{
   display: flex
   align-items: center
   gap: base.$space-xs
+  font-family: var(--lb-font-label)
   font-size: typography.$font-size-label-small // 12px
   line-height: typography.$line-height-normal
   color: var(--lb-text-neutral-contrast-low)

--- a/src/components/Label/LbLabel.vue
+++ b/src/components/Label/LbLabel.vue
@@ -40,7 +40,7 @@ label
   display: inline-flex
   align-items: center
   gap: base.$space-xs
-  font-family: typography.$font-body
+  font-family: var(--lb-font-label)
   font-size: typography.$font-size-label-base // 14px (0.875rem)
   font-weight: var(--lb-font-weight-label)
   line-height: typography.$line-height-normal

--- a/src/styles/_theme.sass
+++ b/src/styles/_theme.sass
@@ -333,6 +333,7 @@
     // Font families
     --lb-font-heading: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif
     --lb-font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif
+    --lb-font-label: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif
     --lb-font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace
     
     // Font weights

--- a/src/styles/_typography.sass
+++ b/src/styles/_typography.sass
@@ -24,6 +24,7 @@
 // Font families
 $font-heading: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif !default
 $font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif !default
+$font-label: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif !default
 $font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace !default
 
 // Font weights
@@ -128,7 +129,7 @@ p
 // Label styles (for form labels, captions, etc.)
 .label
   font-size: var(--lb-font-size-label-base)
-  font-family: var(--lb-font-body)
+  font-family: var(--lb-font-label)
   font-weight: var(--lb-font-weight-label)
   line-height: var(--lb-line-height-normal)
   letter-spacing: var(--lb-letter-spacing-tight)


### PR DESCRIPTION
Added a new --lb-font-label variable to enable separate font family control for UI elements (buttons, labels, hints, badges, chips) independent from body text. This allows projects to use three distinct font families: headings, body content, and UI labels.

🤖 Generated with [Claude Code](https://claude.ai/code)