### PR TITLE
Release v0.5.8: Chip component color system fix and typography improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.8] - 2025-09-09
+
+### Added
+- **Chip Component Enhancements**
+  - Added `outline` variant for chips with transparent background and colored border
+  - Outline chips fill with color on hover for better interaction feedback
+  - All chip variants now support any color prop (primary, secondary, tertiary, neutral, success, warning, error, info)
+
+### Changed
+- **Typography Scale Updates**
+  - Improved visual hierarchy with larger heading sizes:
+    - h1: 40px-56px (was 32px-48px)
+    - h2: 32px-48px (was 28px-40px)
+    - h3: 28px-40px (was 24px-32px)
+    - h4: 24px-28px (was 20px-24px)
+    - h5: 20px-24px (was 18px-20px)
+  - Display sizes increased for better impact:
+    - Display 1: 56px-96px (was 48px-80px)
+    - Display 2: 48px-72px (was 40px-64px)
+  - Added extra large body text demos to typography showcase
+
+### Fixed
+- **Chip Component Color System**
+  - Fixed chip colors not displaying correctly (all appeared neutral)
+  - Removed hardcoded primary color overrides that were blocking color variants
+  - Filter chips now correctly show neutral by default and display color when selected
+  - Non-interactive chips properly show colors without hover states
+  - Icon colors now match their parent chip's color variant
+
 ## [0.5.7] - 2025-09-08
 
 ### Added

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -29,8 +29,9 @@
         h4 Heading 4
         h5 Heading 5
         h6 Heading 6
-        p This is a regular paragraph with normal text.
+        p.body-xlarge This is extra large body text for display.
         p.body-large This is large body text for emphasis.
+        p This is a regular paragraph with normal text.
         p.body-small This is small body text for fine print.
         p.label.label-large Large Label (16px)
         p.label Base Label (14px)
@@ -134,6 +135,7 @@
             h4 Body Text Weight
             p This is a regular paragraph demonstrating the body font weight. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             p.body-large Large body text with adjusted weight
+            p.body-xlarge Extra large body text with adjusted weight
             p.body-small Small body text with adjusted weight
             LbSnackbar(id="font-weight-demo" :model-value="true" message="Snackbar uses body font weight" variant="info" position="relative" :auto-hide="false")
           

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1523,16 +1523,49 @@
             LbChip(variant="assist" :clickable="false" color="neutral") Category Label
         
         .demo-group
-          h4 Chip Colors
+          h4 Chip Colors - Assist/Tonal Style (Non-interactive)
           .button-row
-            LbChip(variant="filter" color="primary") Primary
-            LbChip(variant="filter" color="secondary") Secondary
-            LbChip(variant="filter" color="tertiary") Tertiary
-            LbChip(variant="filter" color="neutral") Neutral
-            LbChip(variant="filter" color="success") Success
-            LbChip(variant="filter" color="warning") Warning
-            LbChip(variant="filter" color="error") Error
-            LbChip(variant="filter" color="info") Info
+            LbChip(variant="assist" :clickable="false" color="primary") Primary
+            LbChip(variant="assist" :clickable="false" color="secondary") Secondary
+            LbChip(variant="assist" :clickable="false" color="tertiary") Tertiary
+            LbChip(variant="assist" :clickable="false" color="neutral") Neutral
+            LbChip(variant="assist" :clickable="false" color="success") Success
+            LbChip(variant="assist" :clickable="false" color="warning") Warning
+            LbChip(variant="assist" :clickable="false" color="error") Error
+            LbChip(variant="assist" :clickable="false" color="info") Info
+          
+          h4.mt-3 Chip Colors - Input/Filled Style (Non-interactive)
+          .button-row
+            LbChip(variant="input" :clickable="false" color="primary") Primary
+            LbChip(variant="input" :clickable="false" color="secondary") Secondary
+            LbChip(variant="input" :clickable="false" color="tertiary") Tertiary
+            LbChip(variant="input" :clickable="false" color="neutral") Neutral
+            LbChip(variant="input" :clickable="false" color="success") Success
+            LbChip(variant="input" :clickable="false" color="warning") Warning
+            LbChip(variant="input" :clickable="false" color="error") Error
+            LbChip(variant="input" :clickable="false" color="info") Info
+          
+          h4.mt-3 Chip Colors - Outline Style (Non-interactive)
+          .button-row
+            LbChip(variant="outline" :clickable="false" color="primary") Primary
+            LbChip(variant="outline" :clickable="false" color="secondary") Secondary
+            LbChip(variant="outline" :clickable="false" color="tertiary") Tertiary
+            LbChip(variant="outline" :clickable="false" color="neutral") Neutral
+            LbChip(variant="outline" :clickable="false" color="success") Success
+            LbChip(variant="outline" :clickable="false" color="warning") Warning
+            LbChip(variant="outline" :clickable="false" color="error") Error
+            LbChip(variant="outline" :clickable="false" color="info") Info
+          
+          h4.mt-3 Chip Colors - Outline Style (Interactive with Hover)
+          .button-row
+            LbChip(variant="outline" color="primary" @click="handleChipClick") Primary
+            LbChip(variant="outline" color="secondary" @click="handleChipClick") Secondary
+            LbChip(variant="outline" color="tertiary" @click="handleChipClick") Tertiary
+            LbChip(variant="outline" color="neutral" @click="handleChipClick") Neutral
+            LbChip(variant="outline" color="success" @click="handleChipClick") Success
+            LbChip(variant="outline" color="warning" @click="handleChipClick") Warning
+            LbChip(variant="outline" color="error" @click="handleChipClick") Error
+            LbChip(variant="outline" color="info" @click="handleChipClick") Info
         
         .demo-group
           h4 With Leading Avatar

--- a/littlebrand-overrides-template.sass
+++ b/littlebrand-overrides-template.sass
@@ -85,8 +85,8 @@
   // --lb-font-size-label-large: 1rem
   
   // Display Sizes (for hero text)
-  // --lb-display-1: clamp(3rem, 5vw + 1rem, 5rem)
-  // --lb-display-2: clamp(2.5rem, 4vw + 1rem, 4rem)
+  // --lb-display-1: clamp(3.5rem, 5vw + 1rem, 6rem)
+  // --lb-display-2: clamp(3rem, 4vw + 1rem, 4.5rem)
   
   // Letter Spacing
   // --lb-letter-spacing-tighter: -0.025em

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littlebrand-ui-kit",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Clean, semantic Vue.js UI kit using Pug & SASS. Zero utility classes, CSS Grid-first, fully themeable.",
   "type": "module",
   "files": [

--- a/src/components/Chip/LbChip.vue
+++ b/src/components/Chip/LbChip.vue
@@ -54,7 +54,7 @@ button.lb-chip(
 import { computed, ref, useSlots } from 'vue'
 
 // Types
-type Variant = 'assist' | 'filter' | 'input' | 'suggestion'
+type Variant = 'assist' | 'filter' | 'input' | 'suggestion' | 'outline'
 type Color = 'primary' | 'secondary' | 'tertiary' | 'neutral' | 'success' | 'warning' | 'error' | 'info'
 
 // Props
@@ -201,70 +201,36 @@ defineOptions({
   
   // Variant styles
   &.variant-assist
-    border-color: var(--lb-border-neutral-line)
-    background-color: var(--lb-surface-subtle)
-    color: var(--lb-text-neutral-contrast-high)
+    // Base styles handled by mixin
     
     &:not(.disabled)
       @include base.hover-supported
-        background-color: var(--lb-surface-primary-normal)
-        border-color: var(--lb-border-primary-normal)
-        color: var(--lb-text-primary-normal)
         box-shadow: base.$shadow-sm
       
     &:active:not(.disabled)
-      background-color: var(--lb-surface-primary-hover)
       transform: translateY(1px)
   
   &.variant-filter
-    border-color: var(--lb-border-neutral-line)
-    background-color: var(--lb-surface-subtle)
-    color: var(--lb-text-neutral-contrast-high)
-    
-    &:not(.disabled)
-      @include base.hover-supported
-        background-color: var(--lb-surface-primary-normal)
-        border-color: var(--lb-border-primary-normal)
-        color: var(--lb-text-primary-normal)
-      
-    &.selected
-      background-color: var(--lb-surface-primary-hover)
-      border-color: var(--lb-border-primary-normal)
-      color: var(--lb-text-primary-normal)
-      
-      &:not(.disabled)
-        @include base.hover-supported
-          background-color: var(--lb-surface-primary-active)
+    // Base styles handled by mixin and override below
+    // Selected state handled by mixin
   
   &.variant-input
-    background-color: var(--lb-fill-primary-normal)
-    border-color: var(--lb-border-primary-normal)
-    color: var(--lb-text-on-primary)
+    // Base styles handled by mixin
     
     &:not(.disabled)
       @include base.hover-supported
-        background-color: var(--lb-fill-primary-hover)
         box-shadow: base.$shadow-sm
-      
-    &:active:not(.disabled)
-      background-color: var(--lb-fill-primary-active)
   
   &.variant-suggestion
-    border-color: var(--lb-border-neutral-line)
-    background-color: var(--lb-surface-subtle)
-    color: var(--lb-text-neutral-contrast-low)
+    // Base styles handled by mixin
     
     &:not(.disabled)
       @include base.hover-supported
-        background-color: var(--lb-surface-neutral-hover)
-        border-color: var(--lb-border-neutral-normal)
-        color: var(--lb-text-neutral-contrast-high)
         box-shadow: base.$shadow-sm
-      
-    &:active:not(.disabled)
-      background-color: var(--lb-surface-primary-normal)
-      border-color: var(--lb-border-primary-normal)
-      color: var(--lb-text-primary-normal)
+  
+  &.variant-outline
+    // Base styles handled by mixin
+    // Transparent background with colored border
   
   // Disabled state
   &.disabled
@@ -376,46 +342,38 @@ defineOptions({
 
 // Chip variant color mixin
 @mixin chip-variant($variant, $color)
-  @if $variant == 'assist'
-    &.color-#{$color}
-      border-color: var(--lb-border-neutral-line)
-      background-color: var(--lb-surface-subtle)
-      color: var(--lb-text-neutral-contrast-high)
+  &.color-#{$color}
+    @if $variant == 'assist'
+      // Assist chips show their color
+      border-color: var(--lb-border-#{$color}-line)
+      background-color: var(--lb-surface-#{$color}-normal)
+      color: var(--lb-text-#{$color}-normal)
       
       &:not(.disabled)
         @include base.hover-supported
-          background-color: var(--lb-surface-#{$color}-normal)
+          background-color: var(--lb-surface-#{$color}-hover)
           border-color: var(--lb-border-#{$color}-normal)
-          color: var(--lb-text-#{$color}-normal)
           box-shadow: base.$shadow-sm
         
       &:active:not(.disabled)
-        background-color: var(--lb-surface-#{$color}-hover)
+        background-color: var(--lb-surface-#{$color}-active)
         transform: translateY(1px)
-  
-  @if $variant == 'filter'
-    &.color-#{$color}
-      border-color: var(--lb-border-neutral-line)
-      background-color: var(--lb-surface-subtle)
-      color: var(--lb-text-neutral-contrast-high)
-      
-      &:not(.disabled)
-        @include base.hover-supported
-          background-color: var(--lb-surface-#{$color}-normal)
-          border-color: var(--lb-border-#{$color}-normal)
-          color: var(--lb-text-#{$color}-normal)
-        
+    
+    @if $variant == 'filter'
+      // Filter chips are neutral by default, but we'll override this later
+      // The selected state will use the color
       &.selected
-        background-color: var(--lb-surface-#{$color}-hover)
+        background-color: var(--lb-surface-#{$color}-normal)
         border-color: var(--lb-border-#{$color}-normal)
         color: var(--lb-text-#{$color}-normal)
         
         &:not(.disabled)
           @include base.hover-supported
-            background-color: var(--lb-surface-#{$color}-active)
-  
-  @if $variant == 'input'
-    &.color-#{$color}
+            background-color: var(--lb-surface-#{$color}-hover)
+            border-color: var(--lb-border-#{$color}-active)
+    
+    @if $variant == 'input'
+      // Input chips show their color (filled style)
       background-color: var(--lb-fill-#{$color}-normal)
       border-color: var(--lb-border-#{$color}-normal)
       color: var(--lb-text-on-#{$color})
@@ -427,27 +385,40 @@ defineOptions({
         
       &:active:not(.disabled)
         background-color: var(--lb-fill-#{$color}-active)
-  
-  @if $variant == 'suggestion'
-    &.color-#{$color}
-      border-color: var(--lb-border-neutral-line)
-      background-color: var(--lb-surface-subtle)
-      color: var(--lb-text-neutral-contrast-low)
+    
+    @if $variant == 'suggestion'
+      // Suggestion chips show their color
+      border-color: var(--lb-border-#{$color}-line)
+      background-color: var(--lb-surface-#{$color}-normal)
+      color: var(--lb-text-#{$color}-normal)
       
       &:not(.disabled)
         @include base.hover-supported
-          background-color: var(--lb-surface-neutral-hover)
-          border-color: var(--lb-border-neutral-normal)
-          color: var(--lb-text-neutral-contrast-high)
+          background-color: var(--lb-surface-#{$color}-hover)
+          border-color: var(--lb-border-#{$color}-normal)
           box-shadow: base.$shadow-sm
         
       &:active:not(.disabled)
-        background-color: var(--lb-surface-#{$color}-normal)
-        border-color: var(--lb-border-#{$color}-normal)
-        color: var(--lb-text-#{$color}-normal)
+        background-color: var(--lb-surface-#{$color}-active)
+        border-color: var(--lb-border-#{$color}-active)
+    
+    @if $variant == 'outline'
+      // Outline chips - transparent background with colored border
+      background-color: transparent
+      border-color: var(--lb-border-#{$color}-normal)
+      color: var(--lb-text-#{$color}-normal)
+      
+      &.clickable:not(.disabled)
+        @include base.hover-supported
+          background-color: var(--lb-surface-#{$color}-normal)
+          border-color: var(--lb-border-#{$color}-normal)
+        
+      &.clickable:active:not(.disabled)
+        background-color: var(--lb-surface-#{$color}-hover)
+        border-color: var(--lb-border-#{$color}-active)
 
 // Generate all variant × color combinations
-$variants: ('assist', 'filter', 'input', 'suggestion')
+$variants: ('assist', 'filter', 'input', 'suggestion', 'outline')
 $colors: ('primary', 'secondary', 'tertiary', 'neutral', 'success', 'warning', 'error', 'info')
 
 @each $variant in $variants
@@ -463,4 +434,16 @@ $colors: ('primary', 'secondary', 'tertiary', 'neutral', 'success', 'warning', '
   @each $color in $colors
     &.color-#{$color} .icon-selected
       color: var(--lb-text-#{$color}-normal)
+
+// Filter chips special behavior: neutral by default
+.lb-chip.variant-filter
+  &:not(.selected)
+    background-color: var(--lb-surface-subtle)
+    border-color: var(--lb-border-neutral-line)
+    color: var(--lb-text-neutral-contrast-high)
+    
+    &:not(.disabled)
+      @include base.hover-supported
+        background-color: var(--lb-surface-neutral-hover)
+        border-color: var(--lb-border-neutral-normal)
 </style>

--- a/src/styles/_theme.sass
+++ b/src/styles/_theme.sass
@@ -369,8 +369,8 @@
     --lb-line-height-relaxed: 1.75
     
     // Display sizes (for hero sections, etc.)
-    --lb-display-1: clamp(3rem, 5vw + 1rem, 5rem)
-    --lb-display-2: clamp(2.5rem, 4vw + 1rem, 4rem)
+    --lb-display-1: clamp(3.5rem, 5vw + 1rem, 6rem)
+    --lb-display-2: clamp(3rem, 4vw + 1rem, 4.5rem)
     
     // Stable neutral text colors (non-flipping for overlays/hero sections)
     // These maintain consistent lightness regardless of theme mode

--- a/src/styles/_typography.sass
+++ b/src/styles/_typography.sass
@@ -63,43 +63,43 @@ $letter-spacing-normal: normal !default
 $letter-spacing-wide: 0.025em !default
 
 // Special Display Sizes (for hero sections, etc.)
-$display-1: clamp(3rem, 5vw + 1rem, 5rem) !default
-$display-2: clamp(2.5rem, 4vw + 1rem, 4rem) !default
+$display-1: clamp(3.5rem, 5vw + 1rem, 6rem) !default
+$display-2: clamp(3rem, 4vw + 1rem, 4.5rem) !default
 
 // === TYPOGRAPHY STYLES ===
 // Applied directly to HTML elements
 
 // Headings
 h1
-  font-size: clamp(2rem, 3vw + 0.5rem, 3rem)
+  font-size: clamp(2.5rem, 3vw + 0.5rem, 3.5rem)
   font-family: var(--lb-font-heading)
   font-weight: var(--lb-font-weight-heading)
   line-height: var(--lb-line-height-compact)
   letter-spacing: var(--lb-letter-spacing-tighter)
 
 h2
-  font-size: clamp(1.75rem, 2.5vw + 0.5rem, 2.5rem)
+  font-size: clamp(2rem, 2.5vw + 0.5rem, 3rem)
   font-family: var(--lb-font-heading)
   font-weight: var(--lb-font-weight-heading)
   line-height: var(--lb-line-height-compact)
   letter-spacing: var(--lb-letter-spacing-tighter)
 
 h3
-  font-size: clamp(1.5rem, 2vw + 0.5rem, 2rem)
+  font-size: clamp(1.75rem, 2vw + 0.5rem, 2.5rem)
   font-family: var(--lb-font-heading)
   font-weight: var(--lb-font-weight-heading)
   line-height: var(--lb-line-height-compact)
   letter-spacing: var(--lb-letter-spacing-tight)
 
 h4
-  font-size: clamp(1.25rem, 1.5vw + 0.5rem, 1.5rem)
+  font-size: clamp(1.5rem, 1.5vw + 0.5rem, 1.75rem)
   font-family: var(--lb-font-heading)
   font-weight: var(--lb-font-weight-heading)
   line-height: var(--lb-line-height-normal)
   letter-spacing: var(--lb-letter-spacing-normal)
 
 h5
-  font-size: clamp(1.125rem, 1vw + 0.5rem, 1.25rem)
+  font-size: clamp(1.25rem, 1vw + 0.5rem, 1.5rem)
   font-family: var(--lb-font-heading)
   font-weight: var(--lb-font-weight-heading)
   line-height: var(--lb-line-height-normal)


### PR DESCRIPTION
## Summary
  - Fixed critical chip component color system where all chips appeared neutral
  regardless of color prop
  - Added new outline variant for chips with enhanced interaction states
  - Improved typography scale with better visual hierarchy

  ## Changes

  ### 🐛 Bug Fixes
  - **Chip Component Color System**
    - Fixed chips not displaying colors correctly (all appeared neutral)
    - Removed hardcoded primary color overrides that were blocking color variants
    - Filter chips now correctly show neutral by default and display color when
  selected
    - Non-interactive chips properly show colors without hover states
    - Icon colors now match their parent chip's color variant

  ### ✨ New Features
  - **Chip Component Enhancements**
    - Added `outline` variant for chips with transparent background and colored
  border
    - Outline chips fill with color on hover for better interaction feedback
    - All chip variants now support any color prop (primary, secondary, tertiary,
  neutral, success, warning, error, info)

  ### 💄 UI Improvements
  - **Typography Scale Updates**
    - Improved visual hierarchy with larger heading sizes:
      - h1: 40px-56px (was 32px-48px)
      - h2: 32px-48px (was 28px-40px)
      - h3: 28px-40px (was 24px-32px)
      - h4: 24px-28px (was 20px-24px)
      - h5: 20px-24px (was 18px-20px)
    - Display sizes increased for better impact:
      - Display 1: 56px-96px (was 48px-80px)
      - Display 2: 48px-72px (was 40px-64px)
    - Added extra large body text demos to typography showcase

  ### 📝 Documentation
  - Updated CHANGELOG.md with v0.5.8 release notes
  - Updated littlebrand-overrides-template.sass with new typography values
  - Bumped version to 0.5.8 in package.json

  ## Testing
  - [x] Chip colors display correctly for all variants
  - [x] Filter chips show neutral by default, colored when selected
  - [x] Outline variant works with hover states
  - [x] Typography sizes scale properly at different viewport widths
  - [x] Examples page demonstrates all new features