### PR TITLE
fix: remove letter-spacing from body and label typography

### DIFF
--- a/src/styles/_typography.sass
+++ b/src/styles/_typography.sass
@@ -137,7 +137,6 @@ p
   font-family: var(--lb-font-label)
   font-weight: var(--lb-font-weight-label)
   line-height: var(--lb-line-height-normal)
-  letter-spacing: var(--lb-letter-spacing-tight)
   
   &.label-large
     font-size: var(--lb-font-size-label-large)


### PR DESCRIPTION
Removed letter-spacing property from .label class to ensure all body text and labels use default browser spacing (zero additional spacing).

🤖 Generated with [Claude Code](https://claude.ai/code)