### PR TITLE
feat: add rounded prop to chip component and reduce padding

### DIFF
--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1693,7 +1693,20 @@
             LbChip(type="assist" color="neutral" muted) Muted
             LbChip(type="assist" color="neutral" disabled) Disabled
             LbChip(type="assist" color="neutral" :clickable="false") Non-clickable
-        
+
+          h5 Rounded (Full Border Radius)
+          .button-row
+            LbChip(rounded type="assist" variant="tonal" color="primary" @click="handleChipClick") Primary
+            LbChip(rounded type="assist" variant="filled" color="secondary" @click="handleChipClick") Secondary
+            LbChip(rounded type="assist" variant="outline" color="tertiary" @click="handleChipClick") Tertiary
+            LbChip(rounded type="filter" variant="tonal" color="success" v-model:selected="filterStates.roundedFilter") Filter
+            LbChip(rounded type="input" variant="filled" color="error" deletable @delete="handleChipDelete") Deletable
+            LbChip(rounded type="assist" variant="tonal" color="info" :has-dropdown="true")
+              template(#leadingIcon)
+                svg(viewBox="0 0 24 24" fill="currentColor" width="18" height="18")
+                  path(d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z")
+              | With Icon
+
         .demo-group
           h4 Functional Examples with Dropdowns
           .button-row
@@ -3327,7 +3340,8 @@ const filterStates = ref({
   filled1: false,
   filled2: false,
   filled3: false,
-  filled4: false
+  filled4: false,
+  roundedFilter: false
 })
 
 // Progress demo data

--- a/littlebrand-overrides-template.sass
+++ b/littlebrand-overrides-template.sass
@@ -456,7 +456,7 @@
   
   // Chip Component
   // --lb-chip-height: var(--lb-size-5xl)
-  // --lb-chip-padding-x: var(--lb-space-md)
+  // --lb-chip-padding-x: var(--lb-space-sm)
   // --lb-chip-font-size: var(--lb-font-size-label-base)
   // --lb-chip-icon-size: var(--lb-size-xl)
   // --lb-chip-avatar-size: var(--lb-size-4xl)

--- a/src/components/Chip/LbChip.vue
+++ b/src/components/Chip/LbChip.vue
@@ -69,6 +69,7 @@ const props = withDefaults(defineProps<{
   deletable?: boolean
   hasDropdown?: boolean
   muted?: boolean
+  rounded?: boolean
 }>(), {
   type: 'assist',
   variant: 'tonal',
@@ -78,7 +79,8 @@ const props = withDefaults(defineProps<{
   clickable: true,
   deletable: false,
   hasDropdown: false,
-  muted: false
+  muted: false,
+  rounded: false
 })
 
 // Emits
@@ -107,7 +109,8 @@ const chipClasses = computed(() => [
     'has-leading-icon': !!slots.leadingIcon || !!slots.leadingAvatar || (props.type === 'filter' && props.selected && !slots.leadingIcon && !slots.leadingAvatar),
     'has-trailing-icon': !!slots.trailingIcon || props.deletable || props.hasDropdown,
     'has-dropdown': props.hasDropdown,
-    'muted': props.muted
+    'muted': props.muted,
+    'rounded': props.rounded
   }
 ])
 
@@ -149,7 +152,6 @@ defineOptions({
   font-family: var(--lb-font-label)
   font-weight: var(--lb-font-weight-label)
   line-height: var(--lb-line-height-compact)
-  letter-spacing: var(--lb-letter-spacing-tight)
   cursor: pointer
   transition: all var(--lb-transition-normal)
   text-decoration: none
@@ -159,7 +161,10 @@ defineOptions({
   background-color: var(--lb-surface-subtle)
   color: var(--lb-text-neutral-contrast-high)
   align-self: flex-start  // Prevent stretching in flex containers
-  
+
+  &.rounded
+    border-radius: var(--lb-radius-full)
+
   &:focus-visible
     outline: var(--lb-border-md) solid var(--lb-focus-ring-color)
     outline-offset: var(--lb-space-2xs)

--- a/src/styles/_theme.sass
+++ b/src/styles/_theme.sass
@@ -333,7 +333,7 @@
     // === COMPONENT-SPECIFIC TOKENS ===
     // Chip component
     --lb-chip-height: var(--lb-size-5xl)
-    --lb-chip-padding-x: var(--lb-space-md)
+    --lb-chip-padding-x: var(--lb-space-sm)
     --lb-chip-font-size: var(--lb-font-size-label-base)
     --lb-chip-icon-size: var(--lb-size-xl)
     --lb-chip-avatar-size: var(--lb-size-4xl)


### PR DESCRIPTION
- Added optional `rounded` prop for full/pill-shaped border radius
- Reduced default horizontal padding from 12px to 8px (using --lb-space-sm)
- Added rounded chip examples to demo page
- Updated override template documentation to reflect new padding default

🤖 Generated with [Claude Code](https://claude.ai/code)