### PR TITLE
feat!: swap text normal and contrast-low color steps for better seman…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2025-09-25
+
+### Changed
+- **BREAKING: Text Color Token Contrast Adjustments**
+  - Swapped the color step values for better semantic accuracy:
+    - `--lb-text-{color}-normal` now uses step 11 (was step 9) for higher contrast
+    - `--lb-text-{color}-contrast-low` now uses step 9 (was step 11) for lower contrast
+  - This change affects all color variants: primary, secondary, tertiary, success, warning, error, info, and neutral
+  - **Migration Guide**: If you relied on the previous contrast levels, you may need to switch between `normal` and `contrast-low` variants in your implementations
+
 ## [0.6.0] - 2025-09-18
 
 ### Added

--- a/TOKENS.md
+++ b/TOKENS.md
@@ -3,7 +3,7 @@
 This file contains all available CSS custom properties (tokens) in the LittleBrand UI Kit.
 Use these tokens in your styles instead of hardcoded values.
 
-Generated on: 2025-09-18
+Generated on: 2025-09-25
 
 ## Border Tokens
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littlebrand-ui-kit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Clean, semantic Vue.js UI kit using Pug & SASS. Zero utility classes, CSS Grid-first, fully themeable.",
   "type": "module",
   "files": [

--- a/src/styles/_theme.sass
+++ b/src/styles/_theme.sass
@@ -125,52 +125,52 @@
     
     // === TEXT TOKENS ===
     // Primary
-    --lb-text-primary-normal: var(--lb-primary-9)
+    --lb-text-primary-normal: var(--lb-primary-11)
     --lb-text-primary-contrast-high: var(--lb-primary-12)
-    --lb-text-primary-contrast-low: var(--lb-primary-11)
+    --lb-text-primary-contrast-low: var(--lb-primary-9)
     --lb-text-primary-disabled: var(--lb-primary-7)
     
     // Secondary
-    --lb-text-secondary-normal: var(--lb-secondary-9)
+    --lb-text-secondary-normal: var(--lb-secondary-11)
     --lb-text-secondary-contrast-high: var(--lb-secondary-12)
-    --lb-text-secondary-contrast-low: var(--lb-secondary-11)
+    --lb-text-secondary-contrast-low: var(--lb-secondary-9)
     --lb-text-secondary-disabled: var(--lb-secondary-7)
     
     // Tertiary
-    --lb-text-tertiary-normal: var(--lb-tertiary-9)
+    --lb-text-tertiary-normal: var(--lb-tertiary-11)
     --lb-text-tertiary-contrast-high: var(--lb-tertiary-12)
-    --lb-text-tertiary-contrast-low: var(--lb-tertiary-11)
+    --lb-text-tertiary-contrast-low: var(--lb-tertiary-9)
     --lb-text-tertiary-disabled: var(--lb-tertiary-7)
     
     // Success
-    --lb-text-success-normal: var(--lb-success-9)
+    --lb-text-success-normal: var(--lb-success-11)
     --lb-text-success-contrast-high: var(--lb-success-12)
-    --lb-text-success-contrast-low: var(--lb-success-11)
+    --lb-text-success-contrast-low: var(--lb-success-9)
     --lb-text-success-disabled: var(--lb-success-7)
     
     // Warning
-    --lb-text-warning-normal: var(--lb-warning-9)
+    --lb-text-warning-normal: var(--lb-warning-11)
     // Better contrast on light bg - warning needs dark text
     --lb-text-warning-contrast-high: var(--lb-neutral-12)
-    --lb-text-warning-contrast-low: var(--lb-neutral-11)
+    --lb-text-warning-contrast-low: var(--lb-neutral-9)
     --lb-text-warning-disabled: var(--lb-warning-7)
     
     // Error
-    --lb-text-error-normal: var(--lb-error-9)
+    --lb-text-error-normal: var(--lb-error-11)
     --lb-text-error-contrast-high: var(--lb-error-12)
-    --lb-text-error-contrast-low: var(--lb-error-11)
+    --lb-text-error-contrast-low: var(--lb-error-9)
     --lb-text-error-disabled: var(--lb-error-7)
     
     // Info
-    --lb-text-info-normal: var(--lb-info-9)
+    --lb-text-info-normal: var(--lb-info-11)
     --lb-text-info-contrast-high: var(--lb-info-12)
-    --lb-text-info-contrast-low: var(--lb-info-11)
+    --lb-text-info-contrast-low: var(--lb-info-9)
     --lb-text-info-disabled: var(--lb-info-7)
     
     // Neutral
-    --lb-text-neutral-normal: var(--lb-neutral-9)
+    --lb-text-neutral-normal: var(--lb-neutral-11)
     --lb-text-neutral-contrast-high: var(--lb-neutral-12)
-    --lb-text-neutral-contrast-low: var(--lb-neutral-11)
+    --lb-text-neutral-contrast-low: var(--lb-neutral-9)
     --lb-text-neutral-disabled: var(--lb-neutral-7)
     
     // === SURFACE TOKENS ===
@@ -551,51 +551,51 @@
   
   // === TEXT TOKENS ===
   // Primary
-  --lb-text-primary-normal: var(--lb-primary-9)
+  --lb-text-primary-normal: var(--lb-primary-11)
   --lb-text-primary-contrast-high: var(--lb-primary-12)
-  --lb-text-primary-contrast-low: var(--lb-primary-11)
+  --lb-text-primary-contrast-low: var(--lb-primary-9)
   --lb-text-primary-disabled: var(--lb-primary-7)
   
   // Secondary
-  --lb-text-secondary-normal: var(--lb-secondary-9)
+  --lb-text-secondary-normal: var(--lb-secondary-11)
   --lb-text-secondary-contrast-high: var(--lb-secondary-12)
-  --lb-text-secondary-contrast-low: var(--lb-secondary-11)
+  --lb-text-secondary-contrast-low: var(--lb-secondary-9)
   --lb-text-secondary-disabled: var(--lb-secondary-7)
   
   // Tertiary
-  --lb-text-tertiary-normal: var(--lb-tertiary-9)
+  --lb-text-tertiary-normal: var(--lb-tertiary-11)
   --lb-text-tertiary-contrast-high: var(--lb-tertiary-12)
-  --lb-text-tertiary-contrast-low: var(--lb-tertiary-11)
+  --lb-text-tertiary-contrast-low: var(--lb-tertiary-9)
   --lb-text-tertiary-disabled: var(--lb-tertiary-7)
   
   // Success
-  --lb-text-success-normal: var(--lb-success-9)
+  --lb-text-success-normal: var(--lb-success-11)
   --lb-text-success-contrast-high: var(--lb-success-12)
-  --lb-text-success-contrast-low: var(--lb-success-11)
+  --lb-text-success-contrast-low: var(--lb-success-9)
   --lb-text-success-disabled: var(--lb-success-7)
   
   // Warning
-  --lb-text-warning-normal: var(--lb-warning-9)
+  --lb-text-warning-normal: var(--lb-warning-11)
   --lb-text-warning-contrast-high: var(--lb-warning-12)
-  --lb-text-warning-contrast-low: var(--lb-warning-11)
+  --lb-text-warning-contrast-low: var(--lb-warning-9)
   --lb-text-warning-disabled: var(--lb-warning-7)
   
   // Error
-  --lb-text-error-normal: var(--lb-error-9)
+  --lb-text-error-normal: var(--lb-error-11)
   --lb-text-error-contrast-high: var(--lb-error-12)
-  --lb-text-error-contrast-low: var(--lb-error-11)
+  --lb-text-error-contrast-low: var(--lb-error-9)
   --lb-text-error-disabled: var(--lb-error-7)
   
   // Info
-  --lb-text-info-normal: var(--lb-info-9)
+  --lb-text-info-normal: var(--lb-info-11)
   --lb-text-info-contrast-high: var(--lb-info-12)
-  --lb-text-info-contrast-low: var(--lb-info-11)
+  --lb-text-info-contrast-low: var(--lb-info-9)
   --lb-text-info-disabled: var(--lb-info-7)
   
   // Neutral
-  --lb-text-neutral-normal: var(--lb-neutral-9)
+  --lb-text-neutral-normal: var(--lb-neutral-11)
   --lb-text-neutral-contrast-high: var(--lb-neutral-12)
-  --lb-text-neutral-contrast-low: var(--lb-neutral-11)
+  --lb-text-neutral-contrast-low: var(--lb-neutral-9)
   --lb-text-neutral-disabled: var(--lb-neutral-7)
   
   // === SURFACE TOKENS ===


### PR DESCRIPTION
…tics

BREAKING CHANGE: Text color tokens now use more semantically accurate color steps
- --lb-text-{color}-normal now uses step 11 (was step 9) for higher contrast
- --lb-text-{color}-contrast-low now uses step 9 (was step 11) for lower contrast

This affects all color variants: primary, secondary, tertiary, success, warning, error, info, and neutral

chore: prepare v0.7.0 release

🤖 Generated with Claude Code
https://claude.ai/code