### PR TITLE
feat: color system improvements and menu enhancements

### DIFF
--- a/examples/App.vue
+++ b/examples/App.vue
@@ -2810,25 +2810,25 @@ import { applyTheme } from '../src/utils/color-generator.js'
 const isDark = ref(false)
 
 // Default theme colors (for demonstration of dynamic theming)
-// Commented out to use the enhanced SASS color values instead
-// const themeColors = {
-//   primary: '#ff8800',
-//   secondary: '#00bfa5',
-//   tertiary: '#3b82f6',
-//   success: '#22c55e',
-//   warning: '#f59e0b',
-//   error: '#ef4444',
-//   info: '#3b82f6',
-//   neutral: '#6b7280'
-// }
+// Now uses LittleBrand enhanced step 11 values by default
+const themeColors = {
+  primary: '#ff8800',
+  secondary: '#00bfa5',
+  tertiary: '#3b82f6',
+  success: '#22c55e',
+  warning: '#f59e0b',
+  error: '#ef4444',
+  info: '#3b82f6',
+  neutral: '#6b7280'
+}
 
 // Apply theme initially
-// applyTheme(themeColors)
+applyTheme(themeColors)
 
 // Watch dark mode changes and reapply theme
-// watch(isDark, () => {
-//   applyTheme(themeColors)
-// })
+watch(isDark, () => {
+  applyTheme(themeColors)
+})
 
 // Custom theme interactive demo
 

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -2567,23 +2567,15 @@
 
         .demo-group
           h4 Active Color Variants
-          p The activeColor prop changes the highlight color for selected menu items.
+          p The activeColor prop changes the highlight color for selected menu items (neutral or primary).
           .button-row
+            LbMenu(v-model="selectedMenuNeutral" :options="basicMenuOptions" active-color="neutral")
+              template(#trigger)
+                LbButton(variant="tonal" color="neutral") Neutral Active
+
             LbMenu(v-model="selectedMenuPrimary" :options="basicMenuOptions" active-color="primary")
               template(#trigger)
                 LbButton(variant="tonal" color="primary") Primary Active
-
-            LbMenu(v-model="selectedMenuSecondary" :options="basicMenuOptions" active-color="secondary")
-              template(#trigger)
-                LbButton(variant="tonal" color="secondary") Secondary Active
-
-            LbMenu(v-model="selectedMenuSuccess" :options="basicMenuOptions" active-color="success")
-              template(#trigger)
-                LbButton(variant="tonal" color="success") Success Active
-
-            LbMenu(v-model="selectedMenuError" :options="basicMenuOptions" active-color="error")
-              template(#trigger)
-                LbButton(variant="tonal" color="error") Error Active
 
       .component-demo
         h3 Calendar
@@ -3518,14 +3510,8 @@ const navActiveColor = ref('primary')
 const navShowLabels = ref(true)
 
 const navColorOptions = [
-  { value: 'primary', label: 'Primary' },
-  { value: 'secondary', label: 'Secondary' },
-  { value: 'tertiary', label: 'Tertiary' },
   { value: 'neutral', label: 'Neutral' },
-  { value: 'success', label: 'Success' },
-  { value: 'warning', label: 'Warning' },
-  { value: 'error', label: 'Error' },
-  { value: 'info', label: 'Info' }
+  { value: 'primary', label: 'Primary' }
 ]
 
 // Snackbar demo data
@@ -3647,10 +3633,8 @@ const selectedMenuItem = ref('')
 const selectedColor = ref('primary')
 const selectedMonth = ref(new Date().getMonth())
 const selectedYear = ref(new Date().getFullYear())
-const selectedMenuPrimary = ref('Option 1')
-const selectedMenuSecondary = ref('Option 2')
-const selectedMenuSuccess = ref('Option 3')
-const selectedMenuError = ref('Option 4')
+const selectedMenuNeutral = ref('Option 1')
+const selectedMenuPrimary = ref('Option 2')
 const selectedUser = ref('')
 const selectedAction = ref('')
 const selectedWithDisabled = ref('')

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -147,7 +147,28 @@
             h4 Heading Level 4
             h5 Heading Level 5
             h6 Heading Level 6
-      
+
+    section.text-contrast-demo-section
+      h2 Text Contrast Levels
+      p.body-large Visual comparison of text token contrast levels across all colors
+
+      .text-contrast-grid
+        .contrast-demo-card(v-for="colorName in textContrastColors" :key="colorName")
+          h4.contrast-card-title {{ colorName.charAt(0).toUpperCase() + colorName.slice(1) }}
+          .contrast-examples
+            .contrast-item(:style="{ color: `var(--lb-text-${colorName}-contrast-high)` }")
+              span.contrast-label Contrast High
+              span.contrast-step (Step 12)
+            .contrast-item(:style="{ color: `var(--lb-text-${colorName}-normal)` }")
+              span.contrast-label Normal
+              span.contrast-step (Step 11)
+            .contrast-item(:style="{ color: `var(--lb-text-${colorName}-contrast-low)` }")
+              span.contrast-label Contrast Low
+              span.contrast-step (Step 9)
+            .contrast-item(:style="{ color: `var(--lb-text-${colorName}-disabled)` }")
+              span.contrast-label Disabled
+              span.contrast-step (Step 7)
+
     section.color-section
       h2 Color Palette
       .color-grid
@@ -3309,6 +3330,9 @@ const colors = [
   { name: 'Info', var: '--lb-fill-info-normal' },
 ]
 
+// Text contrast demo colors
+const textContrastColors = ['neutral', 'primary', 'secondary', 'tertiary', 'success', 'warning', 'error', 'info']
+
 const buttonVariants = ['filled', 'tonal', 'outline', 'ghost']
 const buttonColors = ['primary', 'secondary', 'tertiary', 'neutral', 'success', 'warning', 'error', 'info']
 
@@ -4044,7 +4068,48 @@ section
           padding: base.$space-md
           background: var(--lb-surface-neutral-subtle)
           border-radius: base.$radius-md
-    
+
+.text-contrast-demo-section
+  .text-contrast-grid
+    display: grid
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))
+    gap: base.$space-lg
+    margin-top: base.$space-lg
+
+  .contrast-demo-card
+    background: var(--lb-surface-base)
+    border: base.$border-sm solid var(--lb-border-neutral-line)
+    border-radius: base.$radius-lg
+    padding: base.$space-md
+
+    .contrast-card-title
+      margin: 0 0 base.$space-md 0
+      font-size: typography.$font-size-label-base
+      font-weight: var(--lb-font-weight-label)
+      color: var(--lb-text-neutral-contrast-high)
+
+  .contrast-examples
+    display: flex
+    flex-direction: column
+    gap: base.$space-xs
+
+  .contrast-item
+    display: flex
+    justify-content: space-between
+    align-items: center
+    padding: base.$space-sm base.$space-md
+    background: transparent
+    border-radius: base.$radius-md
+    font-size: typography.$font-size-label-base
+    min-height: base.$unit-40
+
+    .contrast-label
+      font-weight: var(--lb-font-weight-body)
+
+    .contrast-step
+      font-size: typography.$font-size-label-small
+      opacity: base.$opacity-60
+
 .color-section
   .color-grid
     display: grid

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -2809,25 +2809,26 @@ import { applyTheme } from '../src/utils/color-generator.js'
 
 const isDark = ref(false)
 
-// Default theme colors
-const themeColors = {
-  primary: '#ff8800',
-  secondary: '#00bfa5',
-  tertiary: '#3b82f6',
-  success: '#22c55e',
-  warning: '#f59e0b',
-  error: '#ef4444',
-  info: '#3b82f6',
-  neutral: '#6b7280'
-}
+// Default theme colors (for demonstration of dynamic theming)
+// Commented out to use the enhanced SASS color values instead
+// const themeColors = {
+//   primary: '#ff8800',
+//   secondary: '#00bfa5',
+//   tertiary: '#3b82f6',
+//   success: '#22c55e',
+//   warning: '#f59e0b',
+//   error: '#ef4444',
+//   info: '#3b82f6',
+//   neutral: '#6b7280'
+// }
 
 // Apply theme initially
-applyTheme(themeColors)
+// applyTheme(themeColors)
 
 // Watch dark mode changes and reapply theme
-watch(isDark, () => {
-  applyTheme(themeColors)
-})
+// watch(isDark, () => {
+//   applyTheme(themeColors)
+// })
 
 // Custom theme interactive demo
 

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -2577,6 +2577,21 @@
               template(#trigger)
                 LbButton(variant="tonal" color="primary") Primary Active
 
+        .demo-group
+          h4 Menu Items with Icons
+          p Menu items support leading and trailing icon slots. Text stretches to fill available space.
+          .button-row
+            LbMenu(v-model="selectedMenuWithIcons" :options="basicMenuOptions" active-color="primary")
+              template(#trigger)
+                LbButton(variant="outline") Menu with Icons
+
+              template(#item-icon-leading="{ item }")
+                svg(viewBox="0 0 20 20" fill="currentColor")
+                  path(v-if="item.value === 'Option 1'" d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z")
+                  path(v-else-if="item.value === 'Option 2'" d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z")
+                  path(v-else-if="item.value === 'Option 3'" d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z")
+                  path(v-else d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z")
+
       .component-demo
         h3 Calendar
         p Date selection component with month/year navigation and keyboard support
@@ -3635,6 +3650,7 @@ const selectedMonth = ref(new Date().getMonth())
 const selectedYear = ref(new Date().getFullYear())
 const selectedMenuNeutral = ref('Option 1')
 const selectedMenuPrimary = ref('Option 2')
+const selectedMenuWithIcons = ref('Option 1')
 const selectedUser = ref('')
 const selectedAction = ref('')
 const selectedWithDisabled = ref('')

--- a/src/components/Dropdown/LbDropdown.vue
+++ b/src/components/Dropdown/LbDropdown.vue
@@ -252,7 +252,7 @@ defineOptions({
 
 .dropdown-content
   background: var(--lb-surface-base)
-  border: base.$border-sm solid var(--lb-border-neutral-normal)
+  border: base.$border-sm solid var(--lb-border-neutral-line)
   border-radius: base.$radius-lg
   box-shadow: base.$shadow-lg
   overflow-y: auto

--- a/src/components/Menu/LbMenu.vue
+++ b/src/components/Menu/LbMenu.vue
@@ -532,7 +532,7 @@ onUnmounted(() => {
 
 .menu-search
   padding: base.$space-sm base.$space-sm base.$space-xs
-  border-bottom: base.$border-sm solid var(--lb-border-neutral-normal)
+  border-bottom: base.$border-sm solid var(--lb-border-neutral-line)
   
   form
     margin: 0
@@ -543,7 +543,7 @@ onUnmounted(() => {
   height: base.$size-6xl
   padding: 0 base.$space-sm // 0 8px
   background: var(--lb-surface-base)
-  border: base.$border-sm solid var(--lb-border-neutral-normal)
+  border: base.$border-sm solid var(--lb-border-neutral-line)
   border-radius: base.$radius-sm  // 8px for search inputs inside dropdowns
   font-size: typography.$font-size-label-base
   color: var(--lb-text-neutral-contrast-high)

--- a/src/components/Menu/LbMenu.vue
+++ b/src/components/Menu/LbMenu.vue
@@ -103,7 +103,7 @@ export interface LbMenuProps {
   placement?: MenuPlacement
   virtualScrolling?: boolean
   itemHeight?: number
-  activeColor?: 'primary' | 'secondary' | 'tertiary' | 'neutral' | 'success' | 'warning' | 'error' | 'info'
+  activeColor?: 'neutral' | 'primary'
 }
 
 // Props
@@ -575,37 +575,13 @@ onUnmounted(() => {
 
   &.menu-item-selected
     // Color variants for selected state
-    &.color-primary
-      background: var(--lb-surface-primary-hover-alpha)
-      color: var(--lb-text-primary-contrast-high)
-
-    &.color-secondary
-      background: var(--lb-surface-secondary-hover-alpha)
-      color: var(--lb-text-secondary-contrast-high)
-
-    &.color-tertiary
-      background: var(--lb-surface-tertiary-hover-alpha)
-      color: var(--lb-text-tertiary-contrast-high)
-
     &.color-neutral
       background: var(--lb-surface-neutral-hover-alpha)
       color: var(--lb-text-neutral-contrast-high)
 
-    &.color-success
-      background: var(--lb-surface-success-hover-alpha)
-      color: var(--lb-text-success-contrast-high)
-
-    &.color-warning
-      background: var(--lb-surface-warning-hover-alpha)
-      color: var(--lb-text-warning-contrast-high)
-
-    &.color-error
-      background: var(--lb-surface-error-hover-alpha)
-      color: var(--lb-text-error-contrast-high)
-
-    &.color-info
-      background: var(--lb-surface-info-hover-alpha)
-      color: var(--lb-text-info-contrast-high)
+    &.color-primary
+      background: var(--lb-surface-primary-hover-alpha)
+      color: var(--lb-text-primary-contrast-high)
 
   &.menu-item-disabled
     color: var(--lb-text-neutral-disabled)

--- a/src/components/Menu/LbMenu.vue
+++ b/src/components/Menu/LbMenu.vue
@@ -56,8 +56,27 @@ LbDropdown.lb-menu(
                 :highlighted="highlightedIndex === index"
               )
                 .item-content
+                  //- Leading icon slot
+                  span.icon-leading(v-if="$slots['item-icon-leading']")
+                    slot(
+                      name="item-icon-leading"
+                      :item="item"
+                      :selected="isSelected(item)"
+                    )
+
+                  //- Label (stretches to fill available space)
                   span.item-label(v-html="getHighlightedLabel(item)")
-                  .item-checkmark(v-if="isSelected(item)" :class="`color-${activeColor}`")
+
+                  //- Trailing icon slot
+                  span.icon-trailing(v-if="$slots['item-icon-trailing']")
+                    slot(
+                      name="item-icon-trailing"
+                      :item="item"
+                      :selected="isSelected(item)"
+                    )
+
+                  //- Default trailing checkmark when selected (only if no custom trailing icon)
+                  span.icon-trailing(v-else-if="isSelected(item)" :class="`color-${activeColor}`")
                     svg(
                       width="16"
                       height="16"
@@ -90,6 +109,8 @@ export interface MenuItem {
   label: string
   disabled?: boolean
   type?: 'item' | 'divider'
+  iconLeading?: string  // For future use with icon components
+  iconTrailing?: string // For future use with icon components
 }
 
 export interface LbMenuProps {
@@ -591,9 +612,29 @@ onUnmounted(() => {
 .item-content
   display: flex
   align-items: center
-  justify-content: space-between
   width: 100%
   gap: base.$space-sm // 8px
+
+.icon-leading,
+.icon-trailing
+  display: flex
+  align-items: center
+  justify-content: center
+  flex-shrink: 0
+  width: base.$unit-20  // 20px
+  height: base.$unit-20  // 20px
+
+  // Color variants for trailing icon (checkmark)
+  &.color-neutral
+    color: var(--lb-text-neutral-contrast-high)
+
+  &.color-primary
+    color: var(--lb-text-primary-contrast-high)
+
+  // Default color for leading icons
+  :deep(svg)
+    width: 100%
+    height: 100%
 
 .item-label
   flex: 1
@@ -601,27 +642,13 @@ onUnmounted(() => {
   overflow: hidden
   text-overflow: ellipsis
   white-space: nowrap
+  min-width: 0  // Important for text-overflow to work in flex
 
   :deep(mark)
     background: var(--lb-surface-warning-normal)
     color: var(--lb-text-warning-contrast-high)
     padding: 0 base.$space-2xs // 0 2px
     border-radius: base.$radius-xs
-
-.item-checkmark
-  display: flex
-  align-items: center
-  justify-content: center
-  width: base.$unit-18  // 18px
-  height: base.$unit-18  // 18px
-  flex-shrink: 0
-
-  // Color variants for checkmark icon
-  &.color-neutral
-    color: var(--lb-text-neutral-contrast-high)
-
-  &.color-primary
-    color: var(--lb-text-primary-contrast-high)
 
 .menu-divider
   width: 100%

--- a/src/components/Menu/LbMenu.vue
+++ b/src/components/Menu/LbMenu.vue
@@ -57,7 +57,7 @@ LbDropdown.lb-menu(
               )
                 .item-content
                   span.item-label(v-html="getHighlightedLabel(item)")
-                  .item-checkmark(v-if="isSelected(item)")
+                  .item-checkmark(v-if="isSelected(item)" :class="`color-${activeColor}`")
                     svg(
                       width="16"
                       height="16"
@@ -614,8 +614,14 @@ onUnmounted(() => {
   justify-content: center
   width: base.$unit-18  // 18px
   height: base.$unit-18  // 18px
-  color: var(--lb-text-neutral-contrast-low)
   flex-shrink: 0
+
+  // Color variants for checkmark icon
+  &.color-neutral
+    color: var(--lb-text-neutral-contrast-high)
+
+  &.color-primary
+    color: var(--lb-text-primary-contrast-high)
 
 .menu-divider
   width: 100%

--- a/src/components/Menu/LbMenu.vue
+++ b/src/components/Menu/LbMenu.vue
@@ -582,7 +582,7 @@ onUnmounted(() => {
   border: none
   border-radius: base.$radius-md
   font-size: typography.$font-size-label-base
-  color: var(--lb-text-normal)  // Default: text-normal for non-selected items
+  color: var(--lb-text-neutral-normal)  // Default and hover: text-neutral-normal
   cursor: pointer
   transition: background-color base.$transition, color base.$transition
   box-sizing: border-box
@@ -595,14 +595,14 @@ onUnmounted(() => {
     background: var(--lb-surface-neutral-hover-alpha)
 
   &.menu-item-selected
-    // Color variants for selected state
+    // Color variants for active/selected state
     &.color-neutral
       background: var(--lb-surface-neutral-hover-alpha)
-      color: var(--lb-text-neutral-contrast-high)  // High contrast when selected
+      color: var(--lb-text-neutral-contrast-high)  // Active: text-neutral-contrast-high
 
     &.color-primary
       background: var(--lb-surface-primary-hover-alpha)
-      color: var(--lb-text-primary-contrast-high)  // High contrast when selected
+      color: var(--lb-text-primary-contrast-high)  // Active: text-primary-contrast-high
 
   &.menu-item-disabled
     color: var(--lb-text-neutral-disabled)
@@ -623,14 +623,14 @@ onUnmounted(() => {
   flex-shrink: 0
   width: base.$unit-20  // 20px
   height: base.$unit-20  // 20px
-  color: inherit  // Inherit color from parent menu-item (text-normal by default)
+  color: inherit  // Inherit from parent (text-neutral-normal by default, contrast-high when active)
 
-  // Color variants for trailing icon (checkmark when selected)
+  // Color variants for trailing icon (checkmark when selected/active)
   &.color-neutral
-    color: var(--lb-text-neutral-contrast-high)
+    color: var(--lb-text-neutral-contrast-high)  // Active: contrast-high
 
   &.color-primary
-    color: var(--lb-text-primary-contrast-high)
+    color: var(--lb-text-primary-contrast-high)  // Active: contrast-high
 
   :deep(svg)
     width: 100%

--- a/src/components/Menu/LbMenu.vue
+++ b/src/components/Menu/LbMenu.vue
@@ -582,7 +582,7 @@ onUnmounted(() => {
   border: none
   border-radius: base.$radius-md
   font-size: typography.$font-size-label-base
-  color: var(--lb-text-neutral-contrast-high)
+  color: var(--lb-text-normal)  // Default: text-normal for non-selected items
   cursor: pointer
   transition: background-color base.$transition, color base.$transition
   box-sizing: border-box
@@ -598,11 +598,11 @@ onUnmounted(() => {
     // Color variants for selected state
     &.color-neutral
       background: var(--lb-surface-neutral-hover-alpha)
-      color: var(--lb-text-neutral-contrast-high)
+      color: var(--lb-text-neutral-contrast-high)  // High contrast when selected
 
     &.color-primary
       background: var(--lb-surface-primary-hover-alpha)
-      color: var(--lb-text-primary-contrast-high)
+      color: var(--lb-text-primary-contrast-high)  // High contrast when selected
 
   &.menu-item-disabled
     color: var(--lb-text-neutral-disabled)
@@ -623,15 +623,15 @@ onUnmounted(() => {
   flex-shrink: 0
   width: base.$unit-20  // 20px
   height: base.$unit-20  // 20px
+  color: inherit  // Inherit color from parent menu-item (text-normal by default)
 
-  // Color variants for trailing icon (checkmark)
+  // Color variants for trailing icon (checkmark when selected)
   &.color-neutral
     color: var(--lb-text-neutral-contrast-high)
 
   &.color-primary
     color: var(--lb-text-primary-contrast-high)
 
-  // Default color for leading icons
   :deep(svg)
     width: 100%
     height: 100%

--- a/src/components/NavigationBar/LbNavigationBar.vue
+++ b/src/components/NavigationBar/LbNavigationBar.vue
@@ -7,7 +7,7 @@ nav.lb-navigation-bar(:class="navigationBarClasses")
 import { computed, provide, ref, watch } from 'vue'
 
 // Types
-type ActiveColor = 'primary' | 'secondary' | 'tertiary' | 'neutral' | 'success' | 'warning' | 'error' | 'info'
+type ActiveColor = 'neutral' | 'primary'
 
 // Props
 const props = withDefaults(defineProps<{

--- a/src/components/NavigationBar/LbNavigationBarItem.vue
+++ b/src/components/NavigationBar/LbNavigationBarItem.vue
@@ -149,35 +149,11 @@ defineOptions({
 
 // Color variants - Active states with backgrounds (alpha-4)
 .lb-navigation-bar-item
-  &.active.color-primary
-    background-color: var(--lb-surface-primary-hover-alpha)
-    color: var(--lb-text-primary-contrast-high)
-
-  &.active.color-secondary
-    background-color: var(--lb-surface-secondary-hover-alpha)
-    color: var(--lb-text-secondary-contrast-high)
-
-  &.active.color-tertiary
-    background-color: var(--lb-surface-tertiary-hover-alpha)
-    color: var(--lb-text-tertiary-contrast-high)
-
   &.active.color-neutral
     background-color: var(--lb-surface-neutral-hover-alpha)
     color: var(--lb-text-neutral-contrast-high)
 
-  &.active.color-success
-    background-color: var(--lb-surface-success-hover-alpha)
-    color: var(--lb-text-success-contrast-high)
-
-  &.active.color-warning
-    background-color: var(--lb-surface-warning-hover-alpha)
-    color: var(--lb-text-warning-contrast-high)
-
-  &.active.color-error
-    background-color: var(--lb-surface-error-hover-alpha)
-    color: var(--lb-text-error-contrast-high)
-
-  &.active.color-info
-    background-color: var(--lb-surface-info-hover-alpha)
-    color: var(--lb-text-info-contrast-high)
+  &.active.color-primary
+    background-color: var(--lb-surface-primary-hover-alpha)
+    color: var(--lb-text-primary-contrast-high)
 </style>

--- a/src/components/NavigationBar/LbNavigationBarItem.vue
+++ b/src/components/NavigationBar/LbNavigationBarItem.vue
@@ -99,7 +99,7 @@ defineOptions({
   border-radius: 0
   cursor: pointer
   transition: all base.$transition
-  color: var(--lb-text-normal)  // Default: text-normal for non-active items
+  color: var(--lb-text-neutral-normal)  // Default and hover: text-neutral-normal
   outline: none
   position: relative
   width: 100%
@@ -151,9 +151,9 @@ defineOptions({
 .lb-navigation-bar-item
   &.active.color-neutral
     background-color: var(--lb-surface-neutral-hover-alpha)
-    color: var(--lb-text-neutral-contrast-high)  // High contrast when active
+    color: var(--lb-text-neutral-contrast-high)  // Active: text-neutral-contrast-high
 
   &.active.color-primary
     background-color: var(--lb-surface-primary-hover-alpha)
-    color: var(--lb-text-primary-contrast-high)  // High contrast when active
+    color: var(--lb-text-primary-contrast-high)  // Active: text-primary-contrast-high
 </style>

--- a/src/components/NavigationBar/LbNavigationBarItem.vue
+++ b/src/components/NavigationBar/LbNavigationBarItem.vue
@@ -99,7 +99,7 @@ defineOptions({
   border-radius: 0
   cursor: pointer
   transition: all base.$transition
-  color: var(--lb-text-neutral-contrast-low)
+  color: var(--lb-text-normal)  // Default: text-normal for non-active items
   outline: none
   position: relative
   width: 100%
@@ -151,9 +151,9 @@ defineOptions({
 .lb-navigation-bar-item
   &.active.color-neutral
     background-color: var(--lb-surface-neutral-hover-alpha)
-    color: var(--lb-text-neutral-contrast-high)
+    color: var(--lb-text-neutral-contrast-high)  // High contrast when active
 
   &.active.color-primary
     background-color: var(--lb-surface-primary-hover-alpha)
-    color: var(--lb-text-primary-contrast-high)
+    color: var(--lb-text-primary-contrast-high)  // High contrast when active
 </style>

--- a/src/components/Snackbar/LbSnackbar.vue
+++ b/src/components/Snackbar/LbSnackbar.vue
@@ -165,7 +165,7 @@ defineOptions({
   align-items: stretch
   width: min(cv.$snackbar-max-width, 90%)
   min-height: base.$size-7xl  // 48px
-  padding: base.$space-sm cv.$snackbar-padding  // 8px vertical, 16px horizontal
+  padding: base.$space-sm base.$space-sm base.$space-sm cv.$snackbar-padding  // 8px top/right/bottom, 16px left
   background-color: var(--lb-surface-subtle)
   border: base.$border-sm solid var(--lb-border-neutral-line)
   border-radius: cv.$snackbar-border-radius

--- a/src/styles/_colors.sass
+++ b/src/styles/_colors.sass
@@ -130,7 +130,7 @@ $gray-7: oklch(0.851 0 0)  // #cecece
 $gray-8: oklch(0.792 0 0)  // #bbbbbb
 $gray-9: oklch(0.643 0 0)  // #8d8d8d
 $gray-10: oklch(0.61 0 0)  // #838383
-$gray-11: oklch(0.35 0 0)  // #484848 - Enhanced: closer to step 12
+$gray-11: oklch(0.30 0 0)  // #3d3d3d - Enhanced: very close to step 12
 $gray-12: oklch(0.244 0 0)  // #202020
 
 // Gray Dark Mode - Radix UI Gray
@@ -144,7 +144,7 @@ $gray-dark-7: oklch(0.402 0 0)  // #484848
 $gray-dark-8: oklch(0.489 0 0)  // #606060
 $gray-dark-9: oklch(0.538 0 0)  // #6e6e6e
 $gray-dark-10: oklch(0.583 0 0)  // #7b7b7b
-$gray-dark-11: oklch(0.86 0 0)  // #d9d9d9 - Enhanced: closer to step 12
+$gray-dark-11: oklch(0.90 0 0)  // #e5e5e5 - Enhanced: very close to step 12
 $gray-dark-12: oklch(0.949 0 0)  // #eeeeee
 
 // === Success (Green) - Radix UI Green Scale ===

--- a/src/styles/_colors.sass
+++ b/src/styles/_colors.sass
@@ -130,7 +130,7 @@ $gray-7: oklch(0.851 0 0)  // #cecece
 $gray-8: oklch(0.792 0 0)  // #bbbbbb
 $gray-9: oklch(0.643 0 0)  // #8d8d8d
 $gray-10: oklch(0.61 0 0)  // #838383
-$gray-11: oklch(0.503 0 0)  // #646464
+$gray-11: oklch(0.35 0 0)  // #484848 - Enhanced: closer to step 12
 $gray-12: oklch(0.244 0 0)  // #202020
 
 // Gray Dark Mode - Radix UI Gray
@@ -144,7 +144,7 @@ $gray-dark-7: oklch(0.402 0 0)  // #484848
 $gray-dark-8: oklch(0.489 0 0)  // #606060
 $gray-dark-9: oklch(0.538 0 0)  // #6e6e6e
 $gray-dark-10: oklch(0.583 0 0)  // #7b7b7b
-$gray-dark-11: oklch(0.77 0 0)  // #b4b4b4
+$gray-dark-11: oklch(0.86 0 0)  // #d9d9d9 - Enhanced: closer to step 12
 $gray-dark-12: oklch(0.949 0 0)  // #eeeeee
 
 // === Success (Green) - Radix UI Green Scale ===

--- a/src/styles/_colors.sass
+++ b/src/styles/_colors.sass
@@ -130,7 +130,7 @@ $gray-7: oklch(0.851 0 0)  // #cecece
 $gray-8: oklch(0.792 0 0)  // #bbbbbb
 $gray-9: oklch(0.643 0 0)  // #8d8d8d
 $gray-10: oklch(0.61 0 0)  // #838383
-$gray-11: oklch(0.30 0 0)  // #3d3d3d - Enhanced: very close to step 12
+$gray-11: oklch(0.35 0 0)  // #484848 - Enhanced: balanced gap to step 12
 $gray-12: oklch(0.244 0 0)  // #202020
 
 // Gray Dark Mode - Radix UI Gray
@@ -144,7 +144,7 @@ $gray-dark-7: oklch(0.402 0 0)  // #484848
 $gray-dark-8: oklch(0.489 0 0)  // #606060
 $gray-dark-9: oklch(0.538 0 0)  // #6e6e6e
 $gray-dark-10: oklch(0.583 0 0)  // #7b7b7b
-$gray-dark-11: oklch(0.90 0 0)  // #e5e5e5 - Enhanced: very close to step 12
+$gray-dark-11: oklch(0.86 0 0)  // #d9d9d9 - Enhanced: balanced gap to step 12
 $gray-dark-12: oklch(0.949 0 0)  // #eeeeee
 
 // === Success (Green) - Radix UI Green Scale ===

--- a/src/utils/color-generator.js
+++ b/src/utils/color-generator.js
@@ -67,8 +67,8 @@ export function generateSemanticTokens(name, scale, darkScale = null) {
   tokens[`--lb-fill-${name}-disabled`] = name === 'neutral' ? `var(--lb-${name}-alpha-2)` : `var(--lb-${name}-alpha-4)`
   
   // Text tokens
-  tokens[`--lb-text-${name}-normal`] = getScaleValue(9)
-  tokens[`--lb-text-${name}-contrast-low`] = getScaleValue(11)
+  tokens[`--lb-text-${name}-normal`] = getScaleValue(11)  // Fixed: was 9, should be 11
+  tokens[`--lb-text-${name}-contrast-low`] = getScaleValue(9)  // Fixed: was 11, should be 9
   tokens[`--lb-text-${name}-contrast-high`] = getScaleValue(12)
   tokens[`--lb-text-${name}-disabled`] = getScaleValue(7)
   

--- a/src/utils/oklch-utils.js
+++ b/src/utils/oklch-utils.js
@@ -353,17 +353,27 @@ export function generateOklchScale(baseColor, mode = 'light') {
   
   const curves = RADIX_LIGHTNESS_CURVES[mode];
   const chromaPattern = RADIX_CHROMA_PATTERNS[mode];
-  
+
   // Calculate step 1 for dark mode
   let step1Lightness;
   if (mode === 'dark') {
     step1Lightness = curves[1](oklch.H);
   }
-  
+
+  // LittleBrand enhancement: Pre-calculate step 12 lightness for step 11 calculation
+  // This ensures step 11 is closer to step 12 for better text contrast
+  const step12Lightness = mode === 'light' ? curves[12](oklch.L, oklch.H) : curves[12](oklch.H);
+
+  // LittleBrand enhancement: Define fixed gap between step 11 and step 12
+  // These values prevent step 11 from appearing disabled while maintaining clear hierarchy
+  // Light mode: step 11 is 0.106 lighter than step 12
+  // Dark mode: step 11 is 0.089 darker than step 12
+  const LITTLEBRAND_STEP11_GAP = mode === 'light' ? 0.106 : -0.089;
+
   // Generate each step with Radix-quality curves
   for (let i = 1; i <= 12; i++) {
     let lightness, chroma, hue = oklch.H;
-    
+
     if (i === 9) {
       // Step 9 is always the exact input color
       lightness = oklch.L;
@@ -380,13 +390,18 @@ export function generateOklchScale(baseColor, mode = 'light') {
         lightness = curves[i](step1Lightness);
       }
       chroma = oklch.C * chromaPattern[i - 1];
-    } else if (i === 10 || i === 11) {
-      // Steps 10-11: relative to step 9
+    } else if (i === 10) {
+      // Step 10: relative to step 9
       lightness = curves[i](oklch.L);
       chroma = oklch.C * chromaPattern[i - 1];
+    } else if (i === 11) {
+      // Step 11: LittleBrand enhancement - closer to step 12 for better contrast
+      // Uses fixed gap from step 12 to prevent "disabled" appearance
+      lightness = step12Lightness + LITTLEBRAND_STEP11_GAP;
+      chroma = oklch.C * chromaPattern[i - 1];
     } else if (i === 12) {
-      // Step 12: specific handling
-      lightness = mode === 'light' ? curves[i](oklch.L, oklch.H) : curves[i](oklch.H);
+      // Step 12: specific handling (already calculated above for step 11)
+      lightness = step12Lightness;
       chroma = oklch.C * chromaPattern[i - 1];
     }
     


### PR DESCRIPTION
## Summary

This PR includes comprehensive improvements to the color token system, text contrast hierarchy, and menu component functionality. The main enhancement is making LittleBrand's improved step 11 (text-normal) values the default throughout the system.

### Key Changes

#### Color System Enhancements
- **Enhanced step 11 default**: Modified color scale generator to use LittleBrand's enhanced step 11 values by default (closer to step 12 for better text contrast)
- **Text token mapping fix**: Corrected text-normal (step 11) and text-contrast-low (step 9) mappings in color generator
- **Border token updates**: Changed dropdowns and menus to use border-neutral-line (step 5) for more subtle borders
- **Text contrast demo**: Added visual comparison of all text contrast levels across all colors

#### Menu & Navigation Improvements
- **Simplified activeColor prop**: Reduced from 8 colors to just 'neutral' and 'primary' for practical use
- **Icon slot support**: Added leading/trailing icon slots to menu items matching Button component pattern
- **Proper text hierarchy**: Default state uses text-neutral-normal, active state uses text-{color}-contrast-high
- **Consistent styling**: Menu and NavigationBar components now follow same color patterns

#### Minor Fixes
- **Snackbar padding**: Right padding adjusted to 8px for better spacing balance

### Color System Details

The enhanced step 11 ensures text never appears disabled while maintaining clear visual hierarchy:
- **Light mode**: step 11 is 0.106 lighter than step 12
- **Dark mode**: step 11 is 0.089 darker than step 12

This applies to all users calling `applyTheme()`, making it the LittleBrand UI Kit default rather than standard Radix values.

### Component Changes
- LbMenu: Simplified colors, added icon slots, fixed text hierarchy
- LbNavigationBar/Item: Simplified colors, fixed text hierarchy
- LbDropdown: More subtle borders
- LbSnackbar: Adjusted padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)